### PR TITLE
Support hostPath for storing journal

### DIFF
--- a/deploy/charts/alluxio/templates/master/statefulset.yaml
+++ b/deploy/charts/alluxio/templates/master/statefulset.yaml
@@ -88,6 +88,21 @@ spec:
 {{ include "alluxio.imagePullSecrets" . | indent 6 }}
       {{- end}}
       initContainers:
+      {{- if eq .Values.journal.type "hostPath" }}
+      - name: journal-dir-permission
+        image: {{ .Values.image }}:{{ .Values.imageTag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        command: ["chown", "-R"]
+        args:
+          - {{ .Values.user }}:{{ .Values.group }}
+          - {{ $alluxioJournalDir }}
+        volumeMounts:
+          - name: {{ $alluxioJournalVolumeName }}
+            mountPath: {{ $alluxioJournalDir }}
+      {{- end }}
       {{- if .Values.journal.runFormat}}
       - name: journal-format
         image: {{ .Values.image }}:{{ .Values.imageTag }}
@@ -98,7 +113,7 @@ spec:
             mountPath: {{ $alluxioJournalDir }}
           - name: {{ $fullName }}-alluxio-conf
             mountPath: /opt/alluxio/conf
-      {{- end}}
+      {{- end }}
       containers:
         - name: alluxio-master
           image: {{ .Values.image }}:{{ .Values.imageTag }}
@@ -119,7 +134,6 @@ spec:
             - name: "{{ $key }}"
               value: "{{ $value }}"
             {{- end }}
-
 {{- $probePort := $isHa | ternary "embedded" "rpc" }}
           readinessProbe:
             tcpSocket:
@@ -182,6 +196,13 @@ spec:
         {{- if .Values.pvcMounts }}
 {{- include "alluxio.persistentVolumeClaims" .Values.pvcMounts.master | indent 8 }}
         {{- end }}
+        {{- if eq .Values.journal.type "hostPath" }}
+        - name: {{ $alluxioJournalVolumeName }}
+          hostPath:
+            path: {{ .Values.journal.hostPath }}
+            type: DirectoryOrCreate
+        {{- end }}
+  {{- if eq .Values.journal.type "persistentVolumeClaim" }}
   volumeClaimTemplates:
     - metadata:
         name: {{ $alluxioJournalVolumeName }}
@@ -192,4 +213,5 @@ spec:
         resources:
           requests:
             storage: {{ .Values.journal.size }}
+  {{- end }}
 {{- end }}

--- a/deploy/charts/alluxio/values.yaml
+++ b/deploy/charts/alluxio/values.yaml
@@ -160,15 +160,19 @@ master:
   podAnnotations: {}
 
 # Journal system of Alluxio master.
-# Only Embedded journal is supported at the moment.
-# Persistent Volume is required for storing journal.
 journal:
-  # Size of requested storage capacity for the persistentVolumeClaim
-  size: 1Gi
-  # StorageClass of the Persistent Volume for journal
-  storageClass: "standard"
   # Whether to format the journal directory
   runFormat: false
+  # PersistentVolumeClaim and hostPath are supported for storing journal.
+  type: hostPath
+  # Size of requested storage capacity for the persistentVolumeClaim.
+  # Required for type persistentVolumeClaim. Ignored otherwise.
+  size: 1Gi
+  # Required for type persistentVolumeClaim. Ignored otherwise.
+  storageClass: "standard"
+  # Required for type hostPath. Ignored otherwise.
+  # An initContainer running as root will change the owner of this directory to Alluxio.
+  hostPath: /mnt/alluxio/journal
 
 
 ## Alluxio Worker ##


### PR DESCRIPTION
Pros:
- To users, `hostPath` is easier to setup compared to PV.
- `hostPath` is easier to ensure the journal dir is local (the journal dir is on same host machine as master pod)

Cons:
- Need a root initContainer to do `chown`. Minor security concern.

If any user complains about the root user of initContainer, then they will have to manually setup the permission of the hostPath themselves, which means there's no difference for these users to use PV or hostPath because they have to manually set things up anyways. In that case they can just use PV. Or we can add another switch to indicate whether we should do the chown. We'll address this when someone complains.