### PR TITLE
Remove nameOverride from config

### DIFF
--- a/deploy/charts/alluxio/templates/helpers/_common.tpl
+++ b/deploy/charts/alluxio/templates/helpers/_common.tpl
@@ -9,11 +9,8 @@ See the NOTICE file distributed with this work for information regarding copyrig
 
 {{/* vim: set filetype=mustache: */}}
 
-{{/*
-Expand the name of the chart.
-*/}}
 {{- define "alluxio.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+alluxio
 {{- end }}
 
 {{/*
@@ -22,15 +19,11 @@ We truncate at 32 chars because some Kubernetes name fields are limited to 63 ch
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "alluxio.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 32 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- $name := default .Chart.Name "alluxio" }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 32 | trimSuffix "-" }}
 {{- else }}
 {{- printf "%s-%s" .Release.Name $name | trunc 32 | trimSuffix "-" }}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/deploy/charts/alluxio/values.yaml
+++ b/deploy/charts/alluxio/values.yaml
@@ -9,10 +9,6 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
-# The following value should not be modified in the usual case.
-nameOverride: alluxio
-
-
 ## Common ##
 
 # Docker Image


### PR DESCRIPTION
Remove `nameOverride` from helm chart. The reason lies in the implementation of operator:

1. The fullname of the alluxio cluster depends on the `nameOverride`, according helm chart logic.
2. The name of a `load` job will include the fullname of the alluxio cluster, so that the user would be able to know which data the job is loading.
3. The `load crd`, which provides the parameters to launch underlying `load job`, only has the name of the alluxio cluster as a parameter. So to construct the underlying `load job` name, we grab the alluxio cluster, find `nameOverride`, and then construct the fullname.
4. When we destroy the underlying `load job`, the request doesn't contain the name of the alluxio cluster anymore, and thus there's no way for us to find the name of the underlying `load job`. 
5. Therefore, by removing `nameOverride`, the name of the underlying `load job` doesn't depend on the `nameOverride` anymore, and thus we are able to find and delete the underlying load job.
6. `nameOverride` should not be modified in usual case anyways.