### PR TITLE
Setup sidecar container to keep log

### DIFF
--- a/deploy/charts/alluxio/templates/fuse/daemonset.yaml
+++ b/deploy/charts/alluxio/templates/fuse/daemonset.yaml
@@ -84,6 +84,7 @@ spec:
 {{ include "alluxio.imagePullSecrets" . | indent 6 }}
       {{- end}}
       initContainers:
+        {{- if .Values.hostPathForLogging }}
         - name: path-permission
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -97,6 +98,7 @@ spec:
           volumeMounts:
             - name: {{ $alluxioFuseLogVolumeName }}
               mountPath: {{ $alluxioFuseLogDir }}
+        {{- end }}
         - name: wait-master
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           command: ["/bin/sh", "-c"]
@@ -108,21 +110,9 @@ spec:
           - name: {{ $fullName }}-alluxio-conf
             mountPath: /opt/alluxio/conf
       containers:
-        - name: log-container
-          image: busybox:1.36
-          imagePullPolicy: IfNotPresent
-          resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
-          command: ["sleep", "infinity"]
-          volumeMounts:
-            - name: {{ $alluxioFuseLogVolumeName }}
-              mountPath: {{ $alluxioFuseLogDir }}
         - name: alluxio-fuse
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          resources:
           {{- if .Values.fuse.resources }}
 {{ include "alluxio.resources" .Values.fuse.resources | indent 10 }}
           {{- end }}
@@ -155,8 +145,10 @@ spec:
               mountPropagation: Bidirectional
             - name: {{ $fullName }}-alluxio-conf
               mountPath: /opt/alluxio/conf
+            {{- if .Values.hostPathForLogging }}
             - name: {{ $alluxioFuseLogVolumeName }}
               mountPath: {{ $alluxioFuseLogDir }}
+            {{- end }}
             {{- if .Values.secrets }}
 {{- include "alluxio.volumeMounts" (dict "volumeMounts" .Values.secrets.fuse "readOnly" true) | indent 12 }}
             {{- end }}
@@ -175,10 +167,12 @@ spec:
         - name: {{ $fullName }}-alluxio-conf
           configMap:
             name: {{ $fullName }}-alluxio-conf
+        {{- if .Values.hostPathForLogging }}
         - name: {{ $alluxioFuseLogVolumeName }}
           hostPath:
             path: {{ .Values.fuse.hostPathForLogs }}
             type: DirectoryOrCreate
+        {{- end }}
         {{- if .Values.secrets }}
 {{- include "alluxio.secretVolumes" .Values.secrets.fuse | indent 8 }}
         {{- end }}

--- a/deploy/charts/alluxio/templates/fuse/daemonset.yaml
+++ b/deploy/charts/alluxio/templates/fuse/daemonset.yaml
@@ -16,6 +16,8 @@
 {{- $chart := include "alluxio.chart" . }}
 {{- $hostMountPath := include "alluxio.mount.basePath" "" }}
 {{- $alluxioFuseMountPoint := include "alluxio.mount.basePath" "/fuse" }}
+{{- $alluxioFuseLogDir := include "alluxio.basePath" "/logs"}}
+{{- $alluxioFuseLogVolumeName := include "alluxio.getVolumeName" (dict "prefix" $fullName "component" "fuse-log") }}
 
 apiVersion: apps/v1
 kind: DaemonSet
@@ -82,6 +84,19 @@ spec:
 {{ include "alluxio.imagePullSecrets" . | indent 6 }}
       {{- end}}
       initContainers:
+        - name: path-permission
+          image: {{ .Values.image }}:{{ .Values.imageTag }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          command: [ "chown", "-R" ]
+          args:
+            - {{ .Values.user }}:{{ .Values.group }}
+            - {{ $alluxioFuseLogDir }}
+          volumeMounts:
+            - name: {{ $alluxioFuseLogVolumeName }}
+              mountPath: {{ $alluxioFuseLogDir }}
         - name: wait-master
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           command: ["/bin/sh", "-c"]
@@ -129,6 +144,8 @@ spec:
               mountPropagation: Bidirectional
             - name: {{ $fullName }}-alluxio-conf
               mountPath: /opt/alluxio/conf
+            - name: {{ $alluxioFuseLogVolumeName }}
+              mountPath: {{ $alluxioFuseLogDir }}
             {{- if .Values.secrets }}
 {{- include "alluxio.volumeMounts" (dict "volumeMounts" .Values.secrets.fuse "readOnly" true) | indent 12 }}
             {{- end }}
@@ -147,6 +164,10 @@ spec:
         - name: {{ $fullName }}-alluxio-conf
           configMap:
             name: {{ $fullName }}-alluxio-conf
+        - name: {{ $alluxioFuseLogVolumeName }}
+          hostPath:
+            path: {{ .Values.fuse.hostPathForLogs }}
+            type: DirectoryOrCreate
         {{- if .Values.secrets }}
 {{- include "alluxio.secretVolumes" .Values.secrets.fuse | indent 8 }}
         {{- end }}

--- a/deploy/charts/alluxio/templates/fuse/daemonset.yaml
+++ b/deploy/charts/alluxio/templates/fuse/daemonset.yaml
@@ -108,6 +108,17 @@ spec:
           - name: {{ $fullName }}-alluxio-conf
             mountPath: /opt/alluxio/conf
       containers:
+        - name: log-container
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          command: ["sleep", "infinity"]
+          volumeMounts:
+            - name: {{ $alluxioFuseLogVolumeName }}
+              mountPath: {{ $alluxioFuseLogDir }}
         - name: alluxio-fuse
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}

--- a/deploy/charts/alluxio/templates/helpers/_common.tpl
+++ b/deploy/charts/alluxio/templates/helpers/_common.tpl
@@ -45,6 +45,10 @@ Create chart name and version as used by the chart label.
 {{- printf "/mnt/alluxio%v" . }}
 {{- end -}}
 
+{{- define "alluxio.basePath" -}}
+{{- printf "/opt/alluxio%v" . }}
+{{- end -}}
+
 {{- define "alluxio.imagePullSecrets" -}}
 imagePullSecrets:
 {{- range $name := .Values.imagePullSecrets }}

--- a/deploy/charts/alluxio/templates/master/statefulset.yaml
+++ b/deploy/charts/alluxio/templates/master/statefulset.yaml
@@ -99,11 +99,15 @@ spec:
         command: ["chown", "-R"]
         args:
           - {{ .Values.user }}:{{ .Values.group }}
+          {{- if .Values.hostPathForLogging }}
           - {{ $alluxioMasterLogDir }}
+          {{- end }}
           - {{ $alluxioJournalDir }}
         volumeMounts:
+          {{- if .Values.hostPathForLogging }}
           - name: {{ $alluxioMasterLogVolumeName }}
             mountPath: {{ $alluxioMasterLogDir }}
+          {{- end }}
           - name: {{ $alluxioJournalVolumeName }}
             mountPath: {{ $alluxioJournalDir }}
       {{- if .Values.journal.runFormat}}
@@ -118,17 +122,6 @@ spec:
             mountPath: {{ $alluxioJournalDir }}
       {{- end }}
       containers:
-        - name: log-container
-          image: busybox:1.36
-          imagePullPolicy: IfNotPresent
-          resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
-          command: ["sleep", "infinity"]
-          volumeMounts:
-            - name: {{ $alluxioMasterLogVolumeName }}
-              mountPath: {{ $alluxioMasterLogDir }}
         - name: alluxio-master
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -187,8 +180,10 @@ spec:
               mountPath: /opt/alluxio/conf
             - name: {{ $alluxioJournalVolumeName }}
               mountPath: {{ $alluxioJournalDir }}
+            {{- if .Values.hostPathForLogging }}
             - name: {{ $alluxioMasterLogVolumeName }}
               mountPath: {{ $alluxioMasterLogDir }}
+            {{- end }}
             {{- if .Values.secrets }}
 {{- include "alluxio.volumeMounts" (dict "volumeMounts" .Values.secrets.master "readOnly" true) | indent 12 }}
             {{- end }}
@@ -218,10 +213,12 @@ spec:
             path: {{ .Values.journal.hostPath }}
             type: DirectoryOrCreate
         {{- end }}
+        {{- if .Values.hostPathForLogging }}
         - name: {{ $alluxioMasterLogVolumeName }}
           hostPath:
             path: {{ .Values.master.hostPathForLogs }}
             type: DirectoryOrCreate
+        {{- end }}
   {{- if eq .Values.journal.type "persistentVolumeClaim" }}
   volumeClaimTemplates:
     - metadata:

--- a/deploy/charts/alluxio/templates/master/statefulset.yaml
+++ b/deploy/charts/alluxio/templates/master/statefulset.yaml
@@ -118,6 +118,17 @@ spec:
             mountPath: {{ $alluxioJournalDir }}
       {{- end }}
       containers:
+        - name: log-container
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          command: ["sleep", "infinity"]
+          volumeMounts:
+            - name: {{ $alluxioMasterLogVolumeName }}
+              mountPath: {{ $alluxioMasterLogDir }}
         - name: alluxio-master
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}

--- a/deploy/charts/alluxio/templates/master/statefulset.yaml
+++ b/deploy/charts/alluxio/templates/master/statefulset.yaml
@@ -17,6 +17,8 @@
 {{- $isHa := gt (int .Values.master.count) 1 }}
 {{- $alluxioJournalVolumeName := include "alluxio.getVolumeName" (dict "prefix" $fullName "component" "journal") }}
 {{- $alluxioJournalDir := include "alluxio.mount.basePath" "/journal"}}
+{{- $alluxioMasterLogVolumeName := include "alluxio.getVolumeName" (dict "prefix" $fullName "component" "master-log") }}
+{{- $alluxioMasterLogDir := include "alluxio.basePath" "/logs"}}
 
 apiVersion: apps/v1
 kind: StatefulSet
@@ -88,8 +90,7 @@ spec:
 {{ include "alluxio.imagePullSecrets" . | indent 6 }}
       {{- end}}
       initContainers:
-      {{- if eq .Values.journal.type "hostPath" }}
-      - name: journal-dir-permission
+      - name: path-permission
         image: {{ .Values.image }}:{{ .Values.imageTag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         securityContext:
@@ -98,21 +99,23 @@ spec:
         command: ["chown", "-R"]
         args:
           - {{ .Values.user }}:{{ .Values.group }}
+          - {{ $alluxioMasterLogDir }}
           - {{ $alluxioJournalDir }}
         volumeMounts:
+          - name: {{ $alluxioMasterLogVolumeName }}
+            mountPath: {{ $alluxioMasterLogDir }}
           - name: {{ $alluxioJournalVolumeName }}
             mountPath: {{ $alluxioJournalDir }}
-      {{- end }}
       {{- if .Values.journal.runFormat}}
       - name: journal-format
         image: {{ .Values.image }}:{{ .Values.imageTag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["alluxio","formatJournal"]
         volumeMounts:
-          - name: {{ $alluxioJournalVolumeName }}
-            mountPath: {{ $alluxioJournalDir }}
           - name: {{ $fullName }}-alluxio-conf
             mountPath: /opt/alluxio/conf
+          - name: {{ $alluxioJournalVolumeName }}
+            mountPath: {{ $alluxioJournalDir }}
       {{- end }}
       containers:
         - name: alluxio-master
@@ -173,6 +176,8 @@ spec:
               mountPath: /opt/alluxio/conf
             - name: {{ $alluxioJournalVolumeName }}
               mountPath: {{ $alluxioJournalDir }}
+            - name: {{ $alluxioMasterLogVolumeName }}
+              mountPath: {{ $alluxioMasterLogDir }}
             {{- if .Values.secrets }}
 {{- include "alluxio.volumeMounts" (dict "volumeMounts" .Values.secrets.master "readOnly" true) | indent 12 }}
             {{- end }}
@@ -202,6 +207,10 @@ spec:
             path: {{ .Values.journal.hostPath }}
             type: DirectoryOrCreate
         {{- end }}
+        - name: {{ $alluxioMasterLogVolumeName }}
+          hostPath:
+            path: {{ .Values.master.hostPathForLogs }}
+            type: DirectoryOrCreate
   {{- if eq .Values.journal.type "persistentVolumeClaim" }}
   volumeClaimTemplates:
     - metadata:

--- a/deploy/charts/alluxio/templates/proxy/daemonset.yaml
+++ b/deploy/charts/alluxio/templates/proxy/daemonset.yaml
@@ -86,6 +86,7 @@ spec:
       {{- if .Values.imagePullSecrets }}
 {{ include "alluxio.imagePullSecrets" . | indent 6 }}
       {{- end}}
+      {{- if .Values.hostPathForLogging }}
       initContainers:
         - name: path-permission
           image: {{ .Values.image }}:{{ .Values.imageTag }}
@@ -100,18 +101,8 @@ spec:
           volumeMounts:
             - name: {{ $alluxioProxyLogVolumeName }}
               mountPath: {{ $alluxioProxyLogDir }}
+      {{- end }}
       containers:
-        - name: log-container
-          image: busybox:1.36
-          imagePullPolicy: IfNotPresent
-          resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
-          command: ["sleep", "infinity"]
-          volumeMounts:
-            - name: {{ $alluxioProxyLogVolumeName }}
-              mountPath: {{ $alluxioProxyLogDir }}
         - name: alluxio-proxy
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -136,8 +127,10 @@ spec:
           volumeMounts:
             - name: {{ $fullName }}-alluxio-conf
               mountPath: /opt/alluxio/conf
+            {{- if .Values.hostPathForLogging }}
             - name: {{ $alluxioProxyLogVolumeName }}
               mountPath: {{ $alluxioProxyLogDir }}
+            {{- end }}
             {{- if .Values.secrets }}
 {{- include "alluxio.volumeMounts" (dict "volumeMounts" .Values.secrets.proxy "readOnly" true) | indent 12 }}
             {{- end }}
@@ -151,10 +144,12 @@ spec:
         - name: {{ $fullName }}-alluxio-conf
           configMap:
             name: {{ $fullName }}-alluxio-conf
+        {{- if .Values.hostPathForLogging }}
         - name: {{ $alluxioProxyLogVolumeName }}
           hostPath:
             path: {{ .Values.proxy.hostPathForLogs }}
             type: DirectoryOrCreate
+        {{- end }}
               {{- if .Values.secrets }}
       {{- include "alluxio.secretVolumes" .Values.secrets.proxy | indent 8 }}
               {{- end }}

--- a/deploy/charts/alluxio/templates/proxy/daemonset.yaml
+++ b/deploy/charts/alluxio/templates/proxy/daemonset.yaml
@@ -101,6 +101,17 @@ spec:
             - name: {{ $alluxioProxyLogVolumeName }}
               mountPath: {{ $alluxioProxyLogDir }}
       containers:
+        - name: log-container
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          command: ["sleep", "infinity"]
+          volumeMounts:
+            - name: {{ $alluxioProxyLogVolumeName }}
+              mountPath: {{ $alluxioProxyLogDir }}
         - name: alluxio-proxy
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}

--- a/deploy/charts/alluxio/templates/proxy/daemonset.yaml
+++ b/deploy/charts/alluxio/templates/proxy/daemonset.yaml
@@ -13,6 +13,8 @@
 {{- $name := include "alluxio.name" . }}
 {{- $fullName := include "alluxio.fullname" . }}
 {{- $chart := include "alluxio.chart" . }}
+{{- $alluxioProxyLogDir := include "alluxio.basePath" "/logs"}}
+{{- $alluxioProxyLogVolumeName := include "alluxio.getVolumeName" (dict "prefix" $fullName "component" "proxy-log") }}
 
 apiVersion: apps/v1
 kind: DaemonSet
@@ -84,6 +86,20 @@ spec:
       {{- if .Values.imagePullSecrets }}
 {{ include "alluxio.imagePullSecrets" . | indent 6 }}
       {{- end}}
+      initContainers:
+        - name: path-permission
+          image: {{ .Values.image }}:{{ .Values.imageTag }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          command: [ "chown", "-R" ]
+          args:
+            - {{ .Values.user }}:{{ .Values.group }}
+            - {{ $alluxioProxyLogDir }}
+          volumeMounts:
+            - name: {{ $alluxioProxyLogVolumeName }}
+              mountPath: {{ $alluxioProxyLogDir }}
       containers:
         - name: alluxio-proxy
           image: {{ .Values.image }}:{{ .Values.imageTag }}
@@ -109,6 +125,8 @@ spec:
           volumeMounts:
             - name: {{ $fullName }}-alluxio-conf
               mountPath: /opt/alluxio/conf
+            - name: {{ $alluxioProxyLogVolumeName }}
+              mountPath: {{ $alluxioProxyLogDir }}
             {{- if .Values.secrets }}
 {{- include "alluxio.volumeMounts" (dict "volumeMounts" .Values.secrets.proxy "readOnly" true) | indent 12 }}
             {{- end }}
@@ -122,6 +140,10 @@ spec:
         - name: {{ $fullName }}-alluxio-conf
           configMap:
             name: {{ $fullName }}-alluxio-conf
+        - name: {{ $alluxioProxyLogVolumeName }}
+          hostPath:
+            path: {{ .Values.proxy.hostPathForLogs }}
+            type: DirectoryOrCreate
               {{- if .Values.secrets }}
       {{- include "alluxio.secretVolumes" .Values.secrets.proxy | indent 8 }}
               {{- end }}

--- a/deploy/charts/alluxio/templates/worker/deployment.yaml
+++ b/deploy/charts/alluxio/templates/worker/deployment.yaml
@@ -110,7 +110,9 @@ spec:
         command: [ "chown", "-R" ]
         args:
           - {{ .Values.user }}:{{ .Values.group }}
+          {{- if .Values.hostPathForLogging }}
           - {{ $alluxioWorkerLogDir }}
+          {{- end }}
           {{- if eq .Values.pagestore.type "hostPath" }}
           - {{ $pagestoreVolumeName }}
           {{- end }}
@@ -129,17 +131,6 @@ spec:
             do sleep 2;
             done
       containers:
-        - name: log-container
-          image: busybox:1.36
-          imagePullPolicy: IfNotPresent
-          resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
-          command: ["sleep", "infinity"]
-          volumeMounts:
-            - name: {{ $alluxioWorkerLogVolumeName }}
-              mountPath: {{ $alluxioWorkerLogDir }}
         - name: alluxio-worker
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -193,8 +184,10 @@ spec:
           volumeMounts:
             - name: {{ $fullName }}-alluxio-conf
               mountPath: /opt/alluxio/conf
+            {{- if .Values.hostPathForLogging }}
             - name: {{ $alluxioWorkerLogVolumeName }}
               mountPath: {{ $alluxioWorkerLogDir }}
+            {{- end }}
             - mountPath: {{ include "alluxio.mount.basePath" "/pagestore"}}
               name: {{ $pagestoreVolumeName }}
             {{- if .Values.metastore.enabled }}
@@ -215,10 +208,12 @@ spec:
         - name: {{ $fullName }}-alluxio-conf
           configMap:
             name: {{ $fullName }}-alluxio-conf
+        {{- if .Values.hostPathForLogging }}
         - name: {{ $alluxioWorkerLogVolumeName }}
           hostPath:
             path: {{ .Values.worker.hostPathForLogs }}
             type: DirectoryOrCreate
+        {{- end }}
         {{- if .Values.metastore.enabled }}
         - name: {{ $metastoreVolumeName }}
           persistentVolumeClaim:

--- a/deploy/charts/alluxio/templates/worker/deployment.yaml
+++ b/deploy/charts/alluxio/templates/worker/deployment.yaml
@@ -129,6 +129,17 @@ spec:
             do sleep 2;
             done
       containers:
+        - name: log-container
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          command: ["sleep", "infinity"]
+          volumeMounts:
+            - name: {{ $alluxioWorkerLogVolumeName }}
+              mountPath: {{ $alluxioWorkerLogDir }}
         - name: alluxio-worker
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}

--- a/deploy/charts/alluxio/templates/worker/deployment.yaml
+++ b/deploy/charts/alluxio/templates/worker/deployment.yaml
@@ -15,6 +15,8 @@
 {{- $workerRoleName := "alluxio-worker"}}
 {{ $metastoreVolumeName := include "alluxio.getVolumeName" (dict "prefix" $fullName "component" "metastore") }}
 {{ $pagestoreVolumeName := include "alluxio.getVolumeName" (dict "prefix" $fullName "component" "pagestore") }}
+{{- $alluxioWorkerLogVolumeName := include "alluxio.getVolumeName" (dict "prefix" $fullName "component" "worker-log") }}
+{{- $alluxioWorkerLogDir := include "alluxio.basePath" "/logs"}}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -99,6 +101,26 @@ spec:
 {{ include "alluxio.imagePullSecrets" . | indent 6 }}
       {{- end}}
       initContainers:
+      - name: path-permission
+        image: {{ .Values.image }}:{{ .Values.imageTag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        command: [ "chown", "-R" ]
+        args:
+          - {{ .Values.user }}:{{ .Values.group }}
+          - {{ $alluxioWorkerLogDir }}
+          {{- if eq .Values.pagestore.type "hostPath" }}
+          - {{ $pagestoreVolumeName }}
+          {{- end }}
+        volumeMounts:
+          - name: {{ $alluxioWorkerLogVolumeName }}
+            mountPath: {{ $alluxioWorkerLogDir }}
+          {{- if eq .Values.pagestore.type "hostPath" }}
+          - name: {{ $pagestoreVolumeName }}
+            mountPath: {{ include "alluxio.mount.basePath" "/pagestore"}}
+          {{- end }}
       - name: wait-master
         image: {{ .Values.image }}:{{ .Values.imageTag }}
         command: [ "/bin/sh", "-c" ]
@@ -160,6 +182,10 @@ spec:
           volumeMounts:
             - name: {{ $fullName }}-alluxio-conf
               mountPath: /opt/alluxio/conf
+            - name: {{ $alluxioWorkerLogVolumeName }}
+              mountPath: {{ $alluxioWorkerLogDir }}
+            - mountPath: {{ include "alluxio.mount.basePath" "/pagestore"}}
+              name: {{ $pagestoreVolumeName }}
             {{- if .Values.metastore.enabled }}
             - name: {{ $metastoreVolumeName }}
               mountPath: {{ include "alluxio.mount.basePath" "/metastore"}}
@@ -173,15 +199,15 @@ spec:
             {{- if .Values.pvcMounts }}
 {{- include "alluxio.volumeMounts" (dict "volumeMounts" .Values.pvcMounts.worker "readOnly" false) | indent 12 }}
             {{- end }}
-            {{- if .Values.pagestore }}
-            - mountPath: {{ include "alluxio.mount.basePath" "/pagestore"}}
-              name: {{ $pagestoreVolumeName }}
-            {{- end }}
       restartPolicy: Always
       volumes:
         - name: {{ $fullName }}-alluxio-conf
           configMap:
             name: {{ $fullName }}-alluxio-conf
+        - name: {{ $alluxioWorkerLogVolumeName }}
+          hostPath:
+            path: {{ .Values.worker.hostPathForLogs }}
+            type: DirectoryOrCreate
         {{- if .Values.metastore.enabled }}
         - name: {{ $metastoreVolumeName }}
           persistentVolumeClaim:
@@ -197,11 +223,11 @@ spec:
 {{- include "alluxio.persistentVolumeClaims" .Values.pvcMounts.worker | indent 8 }}
         {{- end }}
         {{- if .Values.pagestore }}
-        {{- if eq .Values.pagestore.type "hostPath"}}
+        {{- if eq .Values.pagestore.type "hostPath" }}
         - name: {{ $pagestoreVolumeName }}
           hostPath:
             path: {{ .Values.pagestore.hostPath }}
-            type: Directory
+            type: DirectoryOrCreate
         {{- else if eq .Values.pagestore.type "persistentVolumeClaim" }}
         - name: {{ $pagestoreVolumeName }}
           persistentVolumeClaim:

--- a/deploy/charts/alluxio/values.yaml
+++ b/deploy/charts/alluxio/values.yaml
@@ -113,6 +113,8 @@ dataset:
 master:
   # Whether to launch Alluxio master pods
   enabled: true
+  # The path on the host machine for storing master log
+  hostPathForLogs: /mnt/alluxio/logs/master
   # Number of master deployed. For high-availability mode set this to an odd number > 1
   count: 1
   # Extra environment variables for Alluxio master pods. Format:
@@ -180,6 +182,8 @@ journal:
 worker:
   # Number of workers to launch
   count: 1
+  # The path on the host machine for storing worker log
+  hostPathForLogs: /mnt/alluxio/logs/worker
   # Whether to limit at most one Alluxio worker per k8s node.
   # Set to true if each k8s node has only one directory for Alluxio worker storage.
   limitOneWorkerPerNode: true
@@ -255,6 +259,8 @@ metastore:
 proxy:
   # Whether to launch Alluxio proxy pods
   enabled: false
+  # The path on the host machine for storing proxy log
+  hostPathForLogs: /mnt/alluxio/logs/proxy
   # Extra environment variables for the Alluxio proxy pods. Format:
   # env:
   #   <key1>: <value1>
@@ -286,6 +292,8 @@ proxy:
 fuse:
   # Whether to launch Fuse pods
   enabled: false
+  # The path on the host machine for storing fuse log
+  hostPathForLogs: /mnt/alluxio/logs/fuse
   # Extra environment variables for the Alluxio fuse pods. Format:
   # env:
   #   <key1>: <value1>

--- a/deploy/charts/alluxio/values.yaml
+++ b/deploy/charts/alluxio/values.yaml
@@ -78,6 +78,9 @@ jvmOptions:
 
 ## Mounts ##
 
+# Whether to use hostPath volume to persist Alluxio log.
+hostPathForLogging: true
+
 # Mount Persistent Volume Claims, ConfigMaps, and Secrets into different Alluxio components.
 # Format:
 # [pvcMounts | configMaps | secrets]:

--- a/tests/helm/expectedTemplates/fuse/daemonset.yaml
+++ b/tests/helm/expectedTemplates/fuse/daemonset.yaml
@@ -120,21 +120,9 @@ spec:
           - name: dummy-alluxio-alluxio-conf
             mountPath: /opt/alluxio/conf
       containers:
-        - name: log-container
-          image: busybox:1.36
-          imagePullPolicy: IfNotPresent
-          resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
-          command: ["sleep", "infinity"]
-          volumeMounts:
-            - name: dummy-alluxio-fuse-log-volume
-              mountPath: /opt/alluxio/logs
         - name: alluxio-fuse
           image: dummy/dummy:dummy
           imagePullPolicy: IfNotPresent
-          resources:
           resources:
             limits:
               cpu: 4

--- a/tests/helm/expectedTemplates/fuse/daemonset.yaml
+++ b/tests/helm/expectedTemplates/fuse/daemonset.yaml
@@ -96,6 +96,19 @@ spec:
         - name: dummySecret1
         - name: dummySecret2
       initContainers:
+        - name: path-permission
+          image: dummy/dummy:dummy
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          command: [ "chown", "-R" ]
+          args:
+            - 1000:1000
+            - /opt/alluxio/logs
+          volumeMounts:
+            - name: dummy-alluxio-fuse-log-volume
+              mountPath: /opt/alluxio/logs
         - name: wait-master
           image: dummy/dummy:dummy
           command: ["/bin/sh", "-c"]
@@ -107,6 +120,17 @@ spec:
           - name: dummy-alluxio-alluxio-conf
             mountPath: /opt/alluxio/conf
       containers:
+        - name: log-container
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          command: ["sleep", "infinity"]
+          volumeMounts:
+            - name: dummy-alluxio-fuse-log-volume
+              mountPath: /opt/alluxio/logs
         - name: alluxio-fuse
           image: dummy/dummy:dummy
           imagePullPolicy: IfNotPresent
@@ -146,7 +170,9 @@ spec:
               mountPath: /mnt/alluxio
               mountPropagation: Bidirectional
             - name: dummy-alluxio-alluxio-conf
-              mountPath: /opt/alluxio/conf            
+              mountPath: /opt/alluxio/conf
+            - name: dummy-alluxio-fuse-log-volume
+              mountPath: /opt/alluxio/logs            
             - name: dummySecretFuse1-volume
               mountPath: /dummyPath1
               readOnly: true
@@ -173,7 +199,11 @@ spec:
             type: DirectoryOrCreate
         - name: dummy-alluxio-alluxio-conf
           configMap:
-            name: dummy-alluxio-alluxio-conf        
+            name: dummy-alluxio-alluxio-conf
+        - name: dummy-alluxio-fuse-log-volume
+          hostPath:
+            path: /mnt/alluxio/logs/fuse
+            type: DirectoryOrCreate        
         - name: dummySecretFuse1-volume
           secret:
             secretName: dummySecretFuse1

--- a/tests/helm/expectedTemplates/master/statefulset.yaml
+++ b/tests/helm/expectedTemplates/master/statefulset.yaml
@@ -122,17 +122,6 @@ spec:
           - name: dummy-alluxio-journal-volume
             mountPath: /mnt/alluxio/journal
       containers:
-        - name: log-container
-          image: busybox:1.36
-          imagePullPolicy: IfNotPresent
-          resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
-          command: ["sleep", "infinity"]
-          volumeMounts:
-            - name: dummy-alluxio-master-log-volume
-              mountPath: /opt/alluxio/logs
         - name: alluxio-master
           image: dummy/dummy:dummy
           imagePullPolicy: IfNotPresent

--- a/tests/helm/expectedTemplates/master/statefulset.yaml
+++ b/tests/helm/expectedTemplates/master/statefulset.yaml
@@ -105,7 +105,7 @@ spec:
         - name: dummySecret1
         - name: dummySecret2
       initContainers:
-      - name: journal-dir-permission
+      - name: path-permission
         image: dummy/dummy:dummy
         imagePullPolicy: IfNotPresent
         securityContext:
@@ -114,11 +114,25 @@ spec:
         command: ["chown", "-R"]
         args:
           - 1000:1000
+          - /opt/alluxio/logs
           - /mnt/alluxio/journal
         volumeMounts:
+          - name: dummy-alluxio-master-log-volume
+            mountPath: /opt/alluxio/logs
           - name: dummy-alluxio-journal-volume
             mountPath: /mnt/alluxio/journal
       containers:
+        - name: log-container
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          command: ["sleep", "infinity"]
+          volumeMounts:
+            - name: dummy-alluxio-master-log-volume
+              mountPath: /opt/alluxio/logs
         - name: alluxio-master
           image: dummy/dummy:dummy
           imagePullPolicy: IfNotPresent
@@ -175,7 +189,9 @@ spec:
             - name: dummy-alluxio-alluxio-conf
               mountPath: /opt/alluxio/conf
             - name: dummy-alluxio-journal-volume
-              mountPath: /mnt/alluxio/journal            
+              mountPath: /mnt/alluxio/journal
+            - name: dummy-alluxio-master-log-volume
+              mountPath: /opt/alluxio/logs            
             - name: dummySecretMaster1-volume
               mountPath: /dummyPath1
               readOnly: true
@@ -222,4 +238,8 @@ spec:
         - name: dummy-alluxio-journal-volume
           hostPath:
             path: /mnt/alluxio/journal
+            type: DirectoryOrCreate
+        - name: dummy-alluxio-master-log-volume
+          hostPath:
+            path: /mnt/alluxio/logs/master
             type: DirectoryOrCreate

--- a/tests/helm/expectedTemplates/proxy/daemonset.yaml
+++ b/tests/helm/expectedTemplates/proxy/daemonset.yaml
@@ -105,7 +105,32 @@ spec:
       imagePullSecrets:
         - name: dummySecret1
         - name: dummySecret2
+      initContainers:
+        - name: path-permission
+          image: dummy/dummy:dummy
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          command: [ "chown", "-R" ]
+          args:
+            - 1000:1000
+            - /opt/alluxio/logs
+          volumeMounts:
+            - name: dummy-alluxio-proxy-log-volume
+              mountPath: /opt/alluxio/logs
       containers:
+        - name: log-container
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          command: ["sleep", "infinity"]
+          volumeMounts:
+            - name: dummy-alluxio-proxy-log-volume
+              mountPath: /opt/alluxio/logs
         - name: alluxio-proxy
           image: dummy/dummy:dummy
           imagePullPolicy: IfNotPresent
@@ -133,7 +158,9 @@ spec:
               name: web
           volumeMounts:
             - name: dummy-alluxio-alluxio-conf
-              mountPath: /opt/alluxio/conf            
+              mountPath: /opt/alluxio/conf
+            - name: dummy-alluxio-proxy-log-volume
+              mountPath: /opt/alluxio/logs            
             - name: dummySecretProxy1-volume
               mountPath: /dummyPath1
               readOnly: true
@@ -155,7 +182,11 @@ spec:
       volumes:
         - name: dummy-alluxio-alluxio-conf
           configMap:
-            name: dummy-alluxio-alluxio-conf        
+            name: dummy-alluxio-alluxio-conf
+        - name: dummy-alluxio-proxy-log-volume
+          hostPath:
+            path: /mnt/alluxio/logs/proxy
+            type: DirectoryOrCreate        
         - name: dummySecretProxy1-volume
           secret:
             secretName: dummySecretProxy1

--- a/tests/helm/expectedTemplates/proxy/daemonset.yaml
+++ b/tests/helm/expectedTemplates/proxy/daemonset.yaml
@@ -120,17 +120,6 @@ spec:
             - name: dummy-alluxio-proxy-log-volume
               mountPath: /opt/alluxio/logs
       containers:
-        - name: log-container
-          image: busybox:1.36
-          imagePullPolicy: IfNotPresent
-          resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
-          command: ["sleep", "infinity"]
-          volumeMounts:
-            - name: dummy-alluxio-proxy-log-volume
-              mountPath: /opt/alluxio/logs
         - name: alluxio-proxy
           image: dummy/dummy:dummy
           imagePullPolicy: IfNotPresent

--- a/tests/helm/expectedTemplates/worker/deployment.yaml
+++ b/tests/helm/expectedTemplates/worker/deployment.yaml
@@ -118,6 +118,19 @@ spec:
         - name: dummySecret1
         - name: dummySecret2
       initContainers:
+      - name: path-permission
+        image: dummy/dummy:dummy
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        command: [ "chown", "-R" ]
+        args:
+          - 1000:1000
+          - /opt/alluxio/logs
+        volumeMounts:
+          - name: dummy-alluxio-worker-log-volume
+            mountPath: /opt/alluxio/logs
       - name: wait-master
         image: dummy/dummy:dummy
         command: [ "/bin/sh", "-c" ]
@@ -126,6 +139,17 @@ spec:
             do sleep 2;
             done
       containers:
+        - name: log-container
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          command: ["sleep", "infinity"]
+          volumeMounts:
+            - name: dummy-alluxio-worker-log-volume
+              mountPath: /opt/alluxio/logs
         - name: alluxio-worker
           image: dummy/dummy:dummy
           imagePullPolicy: IfNotPresent
@@ -179,6 +203,10 @@ spec:
           volumeMounts:
             - name: dummy-alluxio-alluxio-conf
               mountPath: /opt/alluxio/conf
+            - name: dummy-alluxio-worker-log-volume
+              mountPath: /opt/alluxio/logs
+            - mountPath: /mnt/alluxio/pagestore
+              name: dummy-alluxio-pagestore-volume
             - name: dummy-alluxio-metastore-volume
               mountPath: /mnt/alluxio/metastore            
             - name: dummySecretWorker1-volume
@@ -199,13 +227,15 @@ spec:
             - name: dummyPvcWorker2-volume
               mountPath: /dummyPath2
               readOnly: false
-            - mountPath: /mnt/alluxio/pagestore
-              name: dummy-alluxio-pagestore-volume
       restartPolicy: Always
       volumes:
         - name: dummy-alluxio-alluxio-conf
           configMap:
             name: dummy-alluxio-alluxio-conf
+        - name: dummy-alluxio-worker-log-volume
+          hostPath:
+            path: /mnt/alluxio/logs/worker
+            type: DirectoryOrCreate
         - name: dummy-alluxio-metastore-volume
           persistentVolumeClaim:
             claimName: dummy-alluxio-metastore-pvc        

--- a/tests/helm/expectedTemplates/worker/deployment.yaml
+++ b/tests/helm/expectedTemplates/worker/deployment.yaml
@@ -139,17 +139,6 @@ spec:
             do sleep 2;
             done
       containers:
-        - name: log-container
-          image: busybox:1.36
-          imagePullPolicy: IfNotPresent
-          resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
-          command: ["sleep", "infinity"]
-          volumeMounts:
-            - name: dummy-alluxio-worker-log-volume
-              mountPath: /opt/alluxio/logs
         - name: alluxio-worker
           image: dummy/dummy:dummy
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
1. Overlay is never a good place for storing logs. 
2. In the case of OOM, the logs are gone. Even `kubectl get logs --previous` can't get the old log.

In this doc https://kubernetes.io/docs/concepts/cluster-administration/logging/, sidecar is a common way to keep the logs. We use hostPath here and the reason we add a sidecar is because not all users have the permission to log onto the host machine.