### PR TITLE
Fix load get alluxiocluster

### DIFF
--- a/api/v1alpha1/dataset_status.go
+++ b/api/v1alpha1/dataset_status.go
@@ -22,5 +22,6 @@ const (
 )
 
 type DatasetStatus struct {
-	Phase DatasetPhase `json:"phase"`
+	BoundedAlluxioCluster string       `json:"boundedAlluxioCluster"`
+	Phase                 DatasetPhase `json:"phase"`
 }

--- a/api/v1alpha1/dataset_types.go
+++ b/api/v1alpha1/dataset_types.go
@@ -30,6 +30,7 @@ type DatasetConf struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="DatasetPhase",type="string",JSONPath=`.status.phase`,priority=0
+// +kubebuilder:printcolumn:name="BoundedAlluxioCluster",type="string",JSONPath=`.status.boundedAlluxioCluster`,priority=0
 
 // Dataset is the Schema for the datasets API
 type Dataset struct {

--- a/api/v1alpha1/load_types.go
+++ b/api/v1alpha1/load_types.go
@@ -20,7 +20,7 @@ type LoadSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="DatasetPhase",type="string",JSONPath=`.status.phase`,priority=0
+// +kubebuilder:printcolumn:name="loadPhase",type="string",JSONPath=`.status.phase`,priority=0
 
 // Load is the Schema for the loads API
 type Load struct {

--- a/deploy/charts/alluxio-operator/crds/k8s-operator.alluxio.com_datasets.yaml
+++ b/deploy/charts/alluxio-operator/crds/k8s-operator.alluxio.com_datasets.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .status.phase
       name: DatasetPhase
       type: string
+    - jsonPath: .status.boundedAlluxioCluster
+      name: BoundedAlluxioCluster
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -65,9 +68,12 @@ spec:
             type: object
           status:
             properties:
+              boundedAlluxioCluster:
+                type: string
               phase:
                 type: string
             required:
+            - boundedAlluxioCluster
             - phase
             type: object
         type: object

--- a/deploy/charts/alluxio-operator/crds/k8s-operator.alluxio.com_loads.yaml
+++ b/deploy/charts/alluxio-operator/crds/k8s-operator.alluxio.com_loads.yaml
@@ -27,7 +27,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.phase
-      name: DatasetPhase
+      name: loadPhase
       type: string
     name: v1alpha1
     schema:

--- a/pkg/alluxiocluster/alluxiocluster_controller.go
+++ b/pkg/alluxiocluster/alluxiocluster_controller.go
@@ -81,6 +81,7 @@ func (r *AlluxioClusterReconciler) Reconcile(context context.Context, req ctrl.R
 			return ctrl.Result{}, err
 		}
 		ctx.Dataset.Status.Phase = alluxiov1alpha1.DatasetPhasePending
+		ctx.Dataset.Status.BoundedAlluxioCluster = ""
 		if err := updateDatasetStatus(ctx); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/pkg/alluxiocluster/delete_alluxiocluster.go
+++ b/pkg/alluxiocluster/delete_alluxiocluster.go
@@ -36,9 +36,14 @@ func DeleteAlluxioClusterIfExist(namespacedName types.NamespacedName) error {
 
 func deleteConfYamlFileIfExist(namespacedName types.NamespacedName) error {
 	confYamlFilePath := utils.GetConfYamlPath(namespacedName)
-	if _, err := os.Stat(confYamlFilePath); err != nil && os.IsNotExist(err) {
-		logger.Errorf("Error getting information of configuration yaml file. %v", err)
-		return err
+	if _, err := os.Stat(confYamlFilePath); err != nil {
+		if os.IsNotExist(err) {
+			logger.Infof("Configuration file already deleted or never existed.")
+			return nil
+		} else {
+			logger.Errorf("Error getting information of configuration yaml file. %v", err)
+			return err
+		}
 	}
 	if err := os.Remove(confYamlFilePath); err != nil {
 		logger.Infof("Failed to delete configuration yaml file. You may need to manually delete it to avoid unexpected behavior. %v", err)

--- a/pkg/alluxiocluster/update_status.go
+++ b/pkg/alluxiocluster/update_status.go
@@ -41,6 +41,7 @@ func UpdateStatus(alluxioClusterCtx AlluxioClusterReconcileReqCtx) (ctrl.Result,
 		if ClusterReady(alluxioClusterCtx) {
 			alluxioClusterNewPhase = alluxiov1alpha1.ClusterPhaseReady
 			datasetNewPhase = alluxiov1alpha1.DatasetPhaseReady
+			alluxioClusterCtx.Dataset.Status.BoundedAlluxioCluster = alluxioClusterCtx.AlluxioCluster.Name
 		} else {
 			alluxioClusterNewPhase = alluxiov1alpha1.ClusterPhaseCreatingOrUpdating
 			datasetNewPhase = alluxiov1alpha1.DatasetPhaseBounding

--- a/pkg/dataset/update_dataset_status.go
+++ b/pkg/dataset/update_dataset_status.go
@@ -27,7 +27,7 @@ func UpdateDatasetStatus(ctx DatasetReconcilerReqCtx) (ctrl.Result, error) {
 		return ctrl.Result{}, err
 	}
 	if !reflect.DeepEqual(newestDataset.Status, ctx.Dataset.Status) {
-		newestDataset.Status.Phase = ctx.Dataset.Status.Phase
+		newestDataset.Status = ctx.Dataset.Status
 		if err := ctx.Client.Status().Update(ctx.Context, newestDataset); err != nil {
 			logger.Errorf("Error updating dataset %s status: %v", ctx.NamespacedName.String(), err)
 			return ctrl.Result{}, err

--- a/resources/crds/k8s-operator.alluxio.com_datasets.yaml
+++ b/resources/crds/k8s-operator.alluxio.com_datasets.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .status.phase
       name: DatasetPhase
       type: string
+    - jsonPath: .status.boundedAlluxioCluster
+      name: BoundedAlluxioCluster
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -65,9 +68,12 @@ spec:
             type: object
           status:
             properties:
+              boundedAlluxioCluster:
+                type: string
               phase:
                 type: string
             required:
+            - boundedAlluxioCluster
             - phase
             type: object
         type: object

--- a/resources/crds/k8s-operator.alluxio.com_loads.yaml
+++ b/resources/crds/k8s-operator.alluxio.com_loads.yaml
@@ -27,7 +27,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.phase
-      name: DatasetPhase
+      name: loadPhase
       type: string
     name: v1alpha1
     schema:


### PR DESCRIPTION
Because alluxiocluster and dataset don't necessarily have same name, and the load command intuitively is more closed to the concept of dataset, load needs to get the alluxiocluster object through dataset for some configurations (e.g. image). Therefore, dataset needs to have the information of which alluxiocluster it is bounded to.