### PR TITLE
[SMALLFIX] Add whitespace on line 28 of configmap.yml

### DIFF
--- a/deploy/charts/alluxio/templates/conf/configmap.yaml
+++ b/deploy/charts/alluxio/templates/conf/configmap.yaml
@@ -25,7 +25,7 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   alluxio-site.properties: |-
-    {{- include "alluxio.site.properties" . | nindent 4}}
+    {{- include "alluxio.site.properties" . | nindent 4 }}
   alluxio-env.sh: |-
     {{- include "alluxio.env" . | nindent 4}}
   metrics.properties: |-

--- a/deploy/charts/alluxio/templates/conf/configmap.yaml
+++ b/deploy/charts/alluxio/templates/conf/configmap.yaml
@@ -27,7 +27,7 @@ data:
   alluxio-site.properties: |-
     {{- include "alluxio.site.properties" . | nindent 4 }}
   alluxio-env.sh: |-
-    {{- include "alluxio.env" . | nindent 4}}
+    {{- include "alluxio.env" . | nindent 4 }}
   metrics.properties: |-
     {{- include "alluxio.metrics.properties" . | nindent 4 }}
   log4j.properties: |-


### PR DESCRIPTION
A whitespace was added between `4` and `}}` on lines 28 and 30 of file https://github.com/Alluxio/k8s-operator/blob/main/deploy/charts/alluxio/templates/conf/configmap.yaml

Fixes Alluxio/new-contributor-tasks#644.

This maintains consistency with the rest of the file.