### PR TITLE
Update dataset status only if it exists when delete alluxio

### DIFF
--- a/pkg/alluxiocluster/alluxiocluster_controller.go
+++ b/pkg/alluxiocluster/alluxiocluster_controller.go
@@ -80,10 +80,12 @@ func (r *AlluxioClusterReconciler) Reconcile(context context.Context, req ctrl.R
 		if err := DeleteAlluxioClusterIfExist(ctx.NamespacedName); err != nil {
 			return ctrl.Result{}, err
 		}
-		ctx.Dataset.Status.Phase = alluxiov1alpha1.DatasetPhasePending
-		ctx.Dataset.Status.BoundedAlluxioCluster = ""
-		if err := updateDatasetStatus(ctx); err != nil {
-			return ctrl.Result{}, err
+		if dataset.Status.Phase != alluxiov1alpha1.DatasetPhaseNotExist {
+			ctx.Dataset.Status.Phase = alluxiov1alpha1.DatasetPhasePending
+			ctx.Dataset.Status.BoundedAlluxioCluster = ""
+			if err := updateDatasetStatus(ctx); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
 		if err := finalizer.RemoveDummyFinalizerIfExist(r.Client, alluxioCluster, context); err != nil {
 			return ctrl.Result{}, err


### PR DESCRIPTION
When we delete the alluxiocluster, we want update the corresponding dataset status, but this should only happen if the dataset exists. If the dataset has been deleted, we can't update its status. On line 69 if the dataset has been deleted, we update the status of the dataset object to `not exist`, which we can leverage here.