### PR TITLE
Fix hostpath for logging

### DIFF
--- a/deploy/charts/alluxio/templates/worker/deployment.yaml
+++ b/deploy/charts/alluxio/templates/worker/deployment.yaml
@@ -120,8 +120,10 @@ spec:
           - {{ $alluxioWorkerPagestorePath }}
           {{- end }}
         volumeMounts:
+          {{- if .Values.hostPathForLogging }}
           - name: {{ $alluxioWorkerLogVolumeName }}
             mountPath: {{ $alluxioWorkerLogDir }}
+          {{- end }}
           {{- if eq .Values.pagestore.type "hostPath" }}
           - name: {{ $pagestoreVolumeName }}
             mountPath: {{ $alluxioWorkerPagestorePath }}


### PR DESCRIPTION
Small fix. Only mount the path in initContainer when hostPathForLogging is true.