### PR TITLE
Add properties to individual Alluxio components

### DIFF
--- a/deploy/charts/alluxio/templates/helpers/_alluxio-env.tpl
+++ b/deploy/charts/alluxio/templates/helpers/_alluxio-env.tpl
@@ -15,6 +15,9 @@ See the NOTICE file distributed with this work for information regarding copyrig
 {{- define "alluxio.master.env" -}}
 {{- $masterJavaOpts := list }}
 {{- $masterJavaOpts = print "-Dalluxio.master.hostname=${ALLUXIO_MASTER_HOSTNAME}" | append $masterJavaOpts }}
+{{- range $key, $val := .Values.master.properties }}
+  {{- $masterJavaOpts = printf "-D%v=%v" $key $val | append $masterJavaOpts }}
+{{- end }}
 {{- if .Values.master.jvmOptions }}
   {{- $masterJavaOpts = concat $masterJavaOpts .Values.master.jvmOptions }}
 {{- end }}
@@ -27,6 +30,9 @@ See the NOTICE file distributed with this work for information regarding copyrig
 {{- define "alluxio.worker.env" -}}
 {{- $workerJavaOpts := list }}
 {{- $workerJavaOpts = print "-Dalluxio.worker.hostname=${ALLUXIO_WORKER_HOSTNAME}" | append $workerJavaOpts }}
+{{- range $key, $val := .Values.worker.properties }}
+  {{- $workerJavaOpts = printf "-D%v=%v" $key $val | append $workerJavaOpts }}
+{{- end }}
 {{- if .Values.worker.jvmOptions }}
   {{- $workerJavaOpts = concat $workerJavaOpts .Values.worker.jvmOptions }}
 {{- end }}
@@ -40,6 +46,9 @@ See the NOTICE file distributed with this work for information regarding copyrig
 {{- $proxyJavaOpts := list }}
 {{- if .Values.proxy.enabled }}
   {{- $proxyJavaOpts = print "-Dalluxio.user.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $proxyJavaOpts }}
+  {{- range $key, $val := .Values.proxy.properties }}
+    {{- $proxyJavaOpts = printf "-D%v=%v" $key $val | append $proxyJavaOpts }}
+  {{- end }}
   {{- if .Values.proxy.jvmOptions }}
     {{- $proxyJavaOpts = concat $proxyJavaOpts .Values.proxy.jvmOptions }}
   {{- end }}
@@ -54,6 +63,9 @@ See the NOTICE file distributed with this work for information regarding copyrig
 {{- $fuseJavaOpts := list }}
 {{- if .Values.fuse.enabled }}
   {{- $fuseJavaOpts = print "-Dalluxio.user.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $fuseJavaOpts }}
+  {{- range $key, $val := .Values.fuse.properties }}
+    {{- $fuseJavaOpts = printf "-D%v=%v" $key $val | append $fuseJavaOpts }}
+  {{- end }}
   {{- if .Values.fuse.jvmOptions }}
     {{- $fuseJavaOpts = concat $fuseJavaOpts .Values.fuse.jvmOptions }}
   {{- end }}

--- a/deploy/charts/alluxio/values.yaml
+++ b/deploy/charts/alluxio/values.yaml
@@ -120,6 +120,8 @@ master:
   hostPathForLogs: /mnt/alluxio/logs/master
   # Number of master deployed. For high-availability mode set this to an odd number > 1
   count: 1
+  # Site properties solely for Alluxio master
+  properties:
   # Extra environment variables for Alluxio master pods. Format:
   # env:
   #   <key1>: <value1>
@@ -190,6 +192,8 @@ worker:
   # Whether to limit at most one Alluxio worker per k8s node.
   # Set to true if each k8s node has only one directory for Alluxio worker storage.
   limitOneWorkerPerNode: true
+  # Site properties solely for Alluxio workers
+  properties:
   # Extra environment variables for the Alluxio worker pods. Format:
   # env:
   #   <key1>: <value1>
@@ -264,6 +268,8 @@ proxy:
   enabled: false
   # The path on the host machine for storing proxy log
   hostPathForLogs: /mnt/alluxio/logs/proxy
+  # Site properties solely for Alluxio proxy
+  properties:
   # Extra environment variables for the Alluxio proxy pods. Format:
   # env:
   #   <key1>: <value1>
@@ -297,6 +303,8 @@ fuse:
   enabled: false
   # The path on the host machine for storing fuse log
   hostPathForLogs: /mnt/alluxio/logs/fuse
+  # Site properties solely for Alluxio Fuse
+  properties:
   # Extra environment variables for the Alluxio fuse pods. Format:
   # env:
   #   <key1>: <value1>


### PR DESCRIPTION
It's hard for users to configure properties via env, because they have to write `ALLUXIO_WORKER_JAVA_OPTS=-Dalluxio.xxxxx` and this requires much more knowledge about Alluxio. It is more natural to use properties.

A common use case is some user property only applies to fuse, but not other clients, for example, `alluxio.user.metadata.cache.enabled`