### PR TITLE
Support multiple hostPath for worker storage

### DIFF
--- a/deploy/charts/alluxio/templates/helpers/_alluxio-site-properties.tpl
+++ b/deploy/charts/alluxio/templates/helpers/_alluxio-site-properties.tpl
@@ -43,7 +43,7 @@ alluxio.master.hostname={{ include "alluxio.fullname" . }}-master-0
 # Page Storage
 alluxio.worker.block.store.type=PAGE
 alluxio.worker.page.store.type=LOCAL
-alluxio.worker.page.store.dirs=/mnt/alluxio/pagestore
+alluxio.worker.page.store.dirs={{ .Values.pagestore.hostPath }}
 {{ printf "alluxio.worker.page.store.sizes=%v" .Values.pagestore.quota }}
 
 {{- if .Values.etcd.enabled }}

--- a/deploy/charts/alluxio/templates/worker/deployment.yaml
+++ b/deploy/charts/alluxio/templates/worker/deployment.yaml
@@ -19,6 +19,24 @@
 {{- $alluxioWorkerPagestorePath := include "alluxio.mount.basePath" "/pagestore" }}
 {{- $alluxioWorkerLogDir := include "alluxio.basePath" "/logs"}}
 
+{{- define "pagestoreHostPathVolumes" -}}
+{{- $paths := splitList "," .Values.pagestore.hostPath }}
+{{- range $i, $path := $paths }}
+- name: pagestore-{{ $i }}
+  hostPath:
+    path: {{ $path }}
+    type: DirectoryOrCreate
+{{- end }}
+{{- end -}}
+
+{{- define "pagestoreHostPathVolumeMounts" -}}
+{{- $paths := splitList "," .Values.pagestore.hostPath }}
+{{- range $i, $path := $paths }}
+- mountPath: {{ $path }}
+  name: pagestore-{{ $i }}
+{{- end }}
+{{- end -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -125,7 +143,7 @@ spec:
             mountPath: {{ $alluxioWorkerLogDir }}
           {{- end }}
           {{- if eq .Values.pagestore.type "hostPath" }}
-          - name: {{ $pagestoreVolumeName }}
+{{- include "pagestoreHostPathVolumeMounts" . | indent 10 }}
             mountPath: {{ $alluxioWorkerPagestorePath }}
           {{- end }}
       - name: wait-master
@@ -193,8 +211,12 @@ spec:
             - name: {{ $alluxioWorkerLogVolumeName }}
               mountPath: {{ $alluxioWorkerLogDir }}
             {{- end }}
+            {{- if eq .Values.pagestore.type "hostPath" }}
+{{- include "pagestoreHostPathVolumeMounts" . | indent 12 }}
+            {{- else }}
             - mountPath: {{ $alluxioWorkerPagestorePath }}
               name: {{ $pagestoreVolumeName }}
+            {{- end }}
             {{- if .Values.metastore.enabled }}
             - name: {{ $metastoreVolumeName }}
               mountPath: {{ include "alluxio.mount.basePath" "/metastore"}}
@@ -233,20 +255,17 @@ spec:
         {{- if .Values.pvcMounts }}
 {{- include "alluxio.persistentVolumeClaims" .Values.pvcMounts.worker | indent 8 }}
         {{- end }}
-        {{- if .Values.pagestore }}
-        - name: {{ $pagestoreVolumeName }}
         {{- if eq .Values.pagestore.type "hostPath" }}
-          hostPath:
-            path: {{ .Values.pagestore.hostPath }}
-            type: DirectoryOrCreate
+{{- include "pagestoreHostPathVolumes" . | indent 8 }}
         {{- else if eq .Values.pagestore.type "persistentVolumeClaim" }}
+        - name: {{ $pagestoreVolumeName }}
           persistentVolumeClaim:
             claimName: {{ include "alluxio.getPvcName" (dict "prefix" $fullName "component" "pagestore") }}
         {{- else if eq .Values.pagestore.type "emptyDir" }}
+        - name: {{ $pagestoreVolumeName }}
           emptyDir:
             sizeLimit: {{ .Values.pagestore.quota }}
             {{- if .Values.pagestore.memoryBacked }}
             medium: "Memory"
             {{- end }}
-        {{- end }}
         {{- end }}

--- a/deploy/charts/alluxio/values.yaml
+++ b/deploy/charts/alluxio/values.yaml
@@ -239,7 +239,8 @@ pagestore:
     type: emptyDir
     # Size of each worker's storage space
     quota: 1Gi
-    # Required for volume type of hostPath, ignored otherwise
+    # Required for volume type of hostPath, ignored otherwise.
+    # To use multiple paths, separating each path with "," and separating each quota with ","
     hostPath: /mnt/alluxio/pagestore
     # Required for volume type of persistentVolumeClaim, ignored otherwise
     storageClass: "standard"

--- a/tests/helm/expectedTemplates/worker/deployment.yaml
+++ b/tests/helm/expectedTemplates/worker/deployment.yaml
@@ -11,8 +11,6 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
-
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
If the physical machines have more than 1 disk, user may want to use all of them for alluxio worker. Support using multiple hostPath for alluxio worker page store.