### PR TITLE
Use a different url for etcd helm chart

### DIFF
--- a/deploy/charts/alluxio/Chart.yaml
+++ b/deploy/charts/alluxio/Chart.yaml
@@ -17,7 +17,7 @@ home: https://www.alluxio.io/
 dependencies:
 - name: etcd
   version: "9.0.5"
-  repository: "oci://registry-1.docker.io/bitnamicharts"
+  repository: "https://charts.bitnami.com/bitnami"
   condition: etcd.enabled
 maintainers:
 - name: Adit Madan


### PR DESCRIPTION
When I run `helm dependency update` I got the following output:
```
Shawns-MBP:alluxio shawnsun$ helm dependency update
Getting updates for unmanaged Helm repositories...
...Unable to get an update from the "oci://registry-1.docker.io/bitnamicharts" chart repository:
	tag explicitly required
Error: repository oci://registry-1.docker.io/bitnamicharts is an OCI registry: this feature has been marked as experimental and is not enabled by default. Please set HELM_EXPERIMENTAL_OCI=1 in your environment to use this feature
```
Using the new url has no such error.