### PR TITLE
Add logic to build helm and docker artifacts

### DIFF
--- a/dev/scripts/.gitignore
+++ b/dev/scripts/.gitignore
@@ -1,0 +1,1 @@
+src/alluxio.org/build-artifact

--- a/dev/scripts/build-artifact.sh
+++ b/dev/scripts/build-artifact.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+set -eu
+
+SCRIPT_DIR=$(cd "$( dirname "$( readlink "$0" || echo "$0" )" )"; pwd)
+
+(cd "${SCRIPT_DIR}/src/alluxio.org/" && GO111MODULE=on go build -o build-artifact "build/main.go")
+
+(cd "${SCRIPT_DIR}" && src/alluxio.org/build-artifact "$@")
+
+rm "${SCRIPT_DIR}/src/alluxio.org/build-artifact"

--- a/dev/scripts/src/alluxio.org/README.md
+++ b/dev/scripts/src/alluxio.org/README.md
@@ -1,0 +1,8 @@
+# Go working environment
+
+Assumes the use of Go 1.18+
+
+## Intellij setup
+
+In Preferences -> Languages & Frameworks -> Go -> Go Modules, check `Enable Go modules integration`
+

--- a/dev/scripts/src/alluxio.org/build/artifact/artifact-methods.go
+++ b/dev/scripts/src/alluxio.org/build/artifact/artifact-methods.go
@@ -1,0 +1,59 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package artifact
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/palantir/stacktrace"
+	"gopkg.in/yaml.v3"
+
+	"alluxio.org/common/command"
+)
+
+func NewArtifactGroup(version string) (*ArtifactGroup, error) {
+	hOut, err := command.New("git rev-parse --short HEAD").Output()
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "error getting commit hash")
+	}
+
+	return &ArtifactGroup{
+		RepoMetadata: &RepoMetadata{
+			CommitHash: strings.TrimSpace(string(hOut)),
+			Version:    version,
+		},
+	}, nil
+}
+
+func (a *ArtifactGroup) Add(artifactType ArtifactType, outputDir, targetName string, metadata map[string]string) *Artifact {
+	newArt := &Artifact{
+		Type:     artifactType,
+		Path:     filepath.Join(outputDir, targetName),
+		Version:  a.RepoMetadata.Version,
+		Metadata: metadata,
+	}
+	a.Artifacts = append(a.Artifacts, newArt)
+	return newArt
+}
+
+func (a *ArtifactGroup) WriteToFile(outputFile string) error {
+	yOut, err := yaml.Marshal(a)
+	if err != nil {
+		return stacktrace.Propagate(err, "error marshalling artifact to yaml")
+	}
+	if err := os.WriteFile(outputFile, yOut, os.ModePerm); err != nil {
+		return stacktrace.Propagate(err, "error writing to file")
+	}
+	return nil
+}

--- a/dev/scripts/src/alluxio.org/build/artifact/artifact.go
+++ b/dev/scripts/src/alluxio.org/build/artifact/artifact.go
@@ -1,0 +1,37 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package artifact
+
+type ArtifactType string
+
+const (
+	DockerArtifact = ArtifactType("docker")
+	HelmArtifact   = ArtifactType("helm")
+)
+
+type RepoMetadata struct {
+	CommitHash string `yaml:"CommitHash,omitempty"`
+	Version    string `yaml:"Version,omitempty"`
+}
+
+type Artifact struct {
+	Type     ArtifactType      `yaml:"Type,omitempty"`
+	Path     string            `yaml:"Path,omitempty"`
+	Version  string            `yaml:"Version,omitempty"`
+	Metadata map[string]string `yaml:"Metadata,omitempty"`
+}
+
+type ArtifactGroup struct {
+	Artifacts []*Artifact `yaml:"Artifacts"`
+
+	RepoMetadata *RepoMetadata `yaml:"RepoMetadata,omitempty"`
+}

--- a/dev/scripts/src/alluxio.org/build/cmd/docker.go
+++ b/dev/scripts/src/alluxio.org/build/cmd/docker.go
@@ -1,0 +1,171 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/palantir/stacktrace"
+	"gopkg.in/yaml.v3"
+
+	"alluxio.org/build/artifact"
+	"alluxio.org/common/command"
+	"alluxio.org/common/repo"
+)
+
+const (
+	defaultDockerYmlFilePath = "src/alluxio.org/build/docker.yml"
+)
+
+type DockerImage struct {
+	Dockerfile string `yaml:"dockerfile"`
+	Tag        string `yaml:"tag"`
+	TargetName string `yaml:"targetName,omitempty"`
+
+	outputTarball string `yaml:"-"`
+}
+
+type dockerBuildOpts struct {
+	artifactOutput string
+	dockerImages   map[string]*DockerImage
+	dockerYmlFile  string
+	image          string
+	metadata       map[string]string
+	outputDir      string
+}
+
+func newDockerBuildOpts(args []string) (*dockerBuildOpts, error) {
+	cmd := flag.NewFlagSet(Docker, flag.ExitOnError)
+	opts := &dockerBuildOpts{
+		metadata: map[string]string{},
+	}
+	var flagMetadata string
+	// docker flags
+	cmd.StringVar(&opts.artifactOutput, "artifact", "", "If set, writes object representing the tarball to YAML output file")
+	cmd.StringVar(&opts.outputDir, "outputDir", repo.FindRepoRoot(), "Set output dir for generated tarball")
+	cmd.StringVar(&opts.dockerYmlFile, "dockerYmlFile", defaultDockerYmlFilePath, "Path to docker.yml file")
+	cmd.StringVar(&opts.image, "image", "", "Choose the docker image to build. See available images in docker.yml")
+	cmd.StringVar(&flagMetadata, "metadata", "", "Set to add metadata key-value pairs. Comma-delimited format (ex. key1=value1,key2=value2")
+
+	// parse flags
+	if err := cmd.Parse(args); err != nil {
+		return nil, stacktrace.Propagate(err, "error parsing flags")
+	}
+
+	// construct metadata from string flag
+	if flagMetadata != "" {
+		for _, pair := range strings.Split(flagMetadata, ",") {
+			kvp := strings.Split(pair, "=")
+			if len(kvp) != 2 {
+				return nil, stacktrace.NewError("expected key and value but got %v", kvp)
+			}
+			opts.metadata[kvp[0]] = kvp[1]
+		}
+	}
+
+	alluxioVersion, err := versionFromChartYaml()
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "error parsing version string")
+	}
+
+	// parse available docker images in docker.yml
+	{
+		wd, err := os.Getwd()
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "error getting current working directory")
+		}
+		dockerYmlPath := filepath.Join(wd, opts.dockerYmlFile)
+		content, err := ioutil.ReadFile(dockerYmlPath)
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "error reading file at %v", dockerYmlPath)
+		}
+		if err := yaml.Unmarshal(content, &opts.dockerImages); err != nil {
+			return nil, stacktrace.Propagate(err, "error unmarshalling docker images from:\n%v", string(content))
+		}
+		for _, img := range opts.dockerImages {
+			img.init(alluxioVersion)
+		}
+	}
+
+	image, ok := opts.dockerImages[opts.image]
+	if !ok {
+		return nil, stacktrace.NewError("must provide valid 'image' arg")
+	}
+	opts.metadata["docker:tag"] = image.Tag
+
+	return opts, nil
+}
+
+func DockerF(args []string) error {
+	opts, err := newDockerBuildOpts(args)
+	if err != nil {
+		return stacktrace.Propagate(err, "error creating docker build opts")
+	}
+
+	alluxioVersion, err := versionFromChartYaml()
+	if err != nil {
+		return stacktrace.Propagate(err, "error parsing version string")
+	}
+
+	image, ok := opts.dockerImages[opts.image]
+	if !ok {
+		return stacktrace.NewError("must provide valid 'image' arg")
+	}
+	if opts.artifactOutput != "" {
+		a, err := artifact.NewArtifactGroup(alluxioVersion)
+		if err != nil {
+			return stacktrace.Propagate(err, "error creating artifact group")
+		}
+		a.Add(artifact.DockerArtifact,
+			opts.outputDir,
+			image.TargetName,
+			opts.metadata,
+		)
+		return a.WriteToFile(opts.artifactOutput)
+	}
+
+	if err := image.build(opts); err != nil {
+		return stacktrace.Propagate(err, "error building image %v", opts.image)
+	}
+
+	return nil
+}
+
+func (i *DockerImage) init(alluxioVersion string) {
+	i.Tag = strings.ReplaceAll(i.Tag, versionPlaceholder, alluxioVersion)
+	i.TargetName = strings.ReplaceAll(i.TargetName, versionPlaceholder, alluxioVersion)
+}
+
+func (i *DockerImage) build(opts *dockerBuildOpts) error {
+	dockerWs := filepath.Join(repo.FindRepoRoot())
+	i.outputTarball = fmt.Sprintf("%v/%v", opts.outputDir, i.TargetName)
+	cmds := []string{
+		fmt.Sprintf("docker build -f %v -t %v %v", i.Dockerfile, i.Tag, dockerWs),
+		fmt.Sprintf("docker save %v -o %v", i.Tag, i.outputTarball),
+	}
+	for _, c := range cmds {
+		log.Printf("Running: %v", c)
+		if out, err := command.New(c).WithDir(repo.FindRepoRoot()).CombinedOutput(); err != nil {
+			return stacktrace.Propagate(err, "error from running cmd: %v", string(out))
+		}
+	}
+	if _, err := os.Stat(i.outputTarball); os.IsNotExist(err) {
+		return stacktrace.Propagate(err, "expected tarball to be created at %v", i.outputTarball)
+	}
+	return nil
+}

--- a/dev/scripts/src/alluxio.org/build/cmd/flags.go
+++ b/dev/scripts/src/alluxio.org/build/cmd/flags.go
@@ -1,0 +1,30 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package cmd
+
+const (
+	Docker  = "docker"
+	Helm    = "helm"
+	Presets = "presets"
+	Version = "version"
+)
+
+var SubCmdNames = []string{
+	Docker,
+	Helm,
+	Presets,
+	Version,
+}
+
+const (
+	versionPlaceholder = `${VERSION}` // used as a placeholder string in tarball names and config files
+)

--- a/dev/scripts/src/alluxio.org/build/cmd/helm.go
+++ b/dev/scripts/src/alluxio.org/build/cmd/helm.go
@@ -1,0 +1,146 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/palantir/stacktrace"
+	"gopkg.in/yaml.v3"
+
+	"alluxio.org/build/artifact"
+	"alluxio.org/common/command"
+	"alluxio.org/common/repo"
+)
+
+const (
+	defaultHelmYmlFilePath = "src/alluxio.org/build/helm.yml"
+)
+
+type HelmChart struct {
+	ChartPath  string `yaml:"chartPath"`
+	Flags      string `yaml:"flags"`
+	TargetName string `yaml:"targetName,omitempty"`
+
+	outputTarball string `yaml:"-"`
+}
+
+type helmBuildOpts struct {
+	artifactOutput string
+	chartName      string
+	helmCharts     map[string]*HelmChart
+	helmYmlFile    string
+	outputDir      string
+}
+
+func newHelmBuildOpts(args []string) (*helmBuildOpts, error) {
+	cmd := flag.NewFlagSet(Helm, flag.ExitOnError)
+	opts := &helmBuildOpts{}
+	// helm flags
+	cmd.StringVar(&opts.artifactOutput, "artifact", "", "If set, writes object representing the tarball to YAML output file")
+	cmd.StringVar(&opts.outputDir, "outputDir", repo.FindRepoRoot(), "Set output dir for generated tarball")
+	cmd.StringVar(&opts.chartName, "chartName", "", "Choose the helm chart to build. See available charts in helm.yml")
+	cmd.StringVar(&opts.helmYmlFile, "helmYmlFile", defaultHelmYmlFilePath, "Path to helm.yml file")
+
+	// parse flags
+	if err := cmd.Parse(args); err != nil {
+		return nil, stacktrace.Propagate(err, "error parsing flags")
+	}
+
+	alluxioVersion, err := versionFromChartYaml()
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "error parsing version string")
+	}
+
+	// parse available helm charts in helm.yml
+	{
+		wd, err := os.Getwd()
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "error getting current working directory")
+		}
+		helmYmlPath := filepath.Join(wd, opts.helmYmlFile)
+		content, err := ioutil.ReadFile(helmYmlPath)
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "error reading file at %v", helmYmlPath)
+		}
+		if err := yaml.Unmarshal(content, &opts.helmCharts); err != nil {
+			return nil, stacktrace.Propagate(err, "error unmarshalling helm charts from:\n%v", string(content))
+		}
+		for _, chart := range opts.helmCharts {
+			chart.init(alluxioVersion)
+		}
+	}
+
+	return opts, nil
+}
+
+func HelmF(args []string) error {
+	opts, err := newHelmBuildOpts(args)
+	if err != nil {
+		return stacktrace.Propagate(err, "error creating helm build opts")
+	}
+
+	alluxioVersion, err := versionFromChartYaml()
+	if err != nil {
+		return stacktrace.Propagate(err, "error parsing version string")
+	}
+
+	chart, ok := opts.helmCharts[opts.chartName]
+	if !ok {
+		return stacktrace.NewError("must provide valid 'chartName' arg")
+	}
+	if opts.artifactOutput != "" {
+		a, err := artifact.NewArtifactGroup(alluxioVersion)
+		if err != nil {
+			return stacktrace.Propagate(err, "error creating artifact group")
+		}
+		a.Add(artifact.HelmArtifact,
+			opts.outputDir,
+			chart.TargetName,
+			nil,
+		)
+		return a.WriteToFile(opts.artifactOutput)
+	}
+
+	if err := chart.build(opts); err != nil {
+		return stacktrace.Propagate(err, "error building helm chart %v", opts.chartName)
+	}
+
+	return nil
+}
+
+func (h *HelmChart) init(alluxioVersion string) {
+	h.TargetName = strings.ReplaceAll(h.TargetName, versionPlaceholder, alluxioVersion)
+}
+
+func (h *HelmChart) build(opts *helmBuildOpts) error {
+	h.outputTarball = fmt.Sprintf("%v/%v", opts.outputDir, h.TargetName)
+	cmds := []string{
+		fmt.Sprintf("helm package %v --destination %v %v", h.ChartPath, opts.outputDir, h.Flags),
+	}
+	for _, c := range cmds {
+		log.Printf("Running: %v", c)
+		if out, err := command.New(c).WithDir(repo.FindRepoRoot()).CombinedOutput(); err != nil {
+			return stacktrace.Propagate(err, "error from running cmd: %v", string(out))
+		}
+	}
+	if _, err := os.Stat(h.outputTarball); os.IsNotExist(err) {
+		return stacktrace.Propagate(err, "expected tarball to be created at %v", h.outputTarball)
+	}
+	return nil
+}

--- a/dev/scripts/src/alluxio.org/build/cmd/preset.go
+++ b/dev/scripts/src/alluxio.org/build/cmd/preset.go
@@ -1,0 +1,118 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package cmd
+
+import (
+	"flag"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/palantir/stacktrace"
+	"gopkg.in/yaml.v3"
+
+	"alluxio.org/build/artifact"
+)
+
+const (
+	defaultPresetsYmlFilePath = "src/alluxio.org/build/presets.yml"
+)
+
+type preset struct {
+	Docker []string `yaml:"docker,omitempty"`
+	Helm   []string `yaml:"helm,omitempty"`
+}
+
+func PresetsF(args []string) error {
+	cmd := flag.NewFlagSet(Presets, flag.ExitOnError)
+	// preset flags
+	var flagArtifactOutput, flagPresetName, flagPresetsYmlFile string
+	cmd.StringVar(&flagArtifactOutput, "artifact", "", "If set, writes object representing the tarball to YAML output file")
+	cmd.StringVar(&flagPresetsYmlFile, "presetsYmlFile", defaultPresetsYmlFilePath, "Path to presets.yml file")
+	cmd.StringVar(&flagPresetName, "name", "", "Choose the preset to build. See available presets in presets.yml")
+
+	//parse flags
+	if err := cmd.Parse(args); err != nil {
+		return stacktrace.Propagate(err, "error parsing flags")
+	}
+	// parse presets.yml
+	var presets map[string]preset
+	{
+		wd, err := os.Getwd()
+		if err != nil {
+			return stacktrace.Propagate(err, "error getting current working directory")
+		}
+		dockerYmlPath := filepath.Join(wd, flagPresetsYmlFile)
+		content, err := ioutil.ReadFile(dockerYmlPath)
+		if err != nil {
+			return stacktrace.Propagate(err, "error reading file at %v", dockerYmlPath)
+		}
+		if err := yaml.Unmarshal(content, &presets); err != nil {
+			return stacktrace.Propagate(err, "error unmarshalling presets from:\n%v", string(content))
+		}
+	}
+
+	p, ok := presets[flagPresetName]
+	if !ok {
+		return stacktrace.NewError("error finding preset named %v", flagPresetName)
+	}
+
+	alluxioVersion, err := versionFromChartYaml()
+	if err != nil {
+		return stacktrace.Propagate(err, "error parsing version string")
+	}
+
+	a, err := artifact.NewArtifactGroup(alluxioVersion)
+	if err != nil {
+		return stacktrace.Propagate(err, "error creating artifact group")
+	}
+	for _, dArgs := range p.Docker {
+		dOpts, err := newDockerBuildOpts(strings.Split(dArgs, " "))
+		if err != nil {
+			return stacktrace.Propagate(err, "error creating docker build opts")
+		}
+		image, ok := dOpts.dockerImages[dOpts.image]
+		if !ok {
+			return stacktrace.NewError("must provide valid 'image' arg")
+		}
+		a.Add(artifact.DockerArtifact, dOpts.outputDir, image.TargetName, dOpts.metadata)
+	}
+	for _, hArgs := range p.Helm {
+		hOpts, err := newHelmBuildOpts(strings.Split(hArgs, " "))
+		if err != nil {
+			return stacktrace.Propagate(err, "error creating helm build opts")
+		}
+		image, ok := hOpts.helmCharts[hOpts.chartName]
+		if !ok {
+			return stacktrace.NewError("must provide valid 'chartName' arg")
+		}
+		a.Add(artifact.HelmArtifact, hOpts.outputDir, image.TargetName, nil)
+	}
+
+	if flagArtifactOutput != "" {
+		return a.WriteToFile(flagArtifactOutput)
+	}
+
+	for _, dArgs := range p.Docker {
+		if err := DockerF(strings.Split(dArgs, " ")); err != nil {
+			return stacktrace.Propagate(err, "error building docker image")
+		}
+	}
+	for _, hArgs := range p.Helm {
+		if err := HelmF(strings.Split(hArgs, " ")); err != nil {
+			return stacktrace.Propagate(err, "error building helm chart")
+		}
+	}
+
+	return nil
+}

--- a/dev/scripts/src/alluxio.org/build/cmd/version.go
+++ b/dev/scripts/src/alluxio.org/build/cmd/version.go
@@ -1,0 +1,54 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/palantir/stacktrace"
+	"gopkg.in/yaml.v3"
+
+	"alluxio.org/common/repo"
+)
+
+const (
+	// using a specific Chart.yaml since all charts and docker images in this repo will be same version
+	alluxioChartYaml = "deploy/charts/alluxio/Chart.yaml"
+)
+
+func VersionF() error {
+	ver, err := versionFromChartYaml()
+	if err != nil {
+		return stacktrace.Propagate(err, "error finding version from %v", alluxioChartYaml)
+	}
+	fmt.Println()
+	fmt.Printf("Alluxio version from %v: %v\n", alluxioChartYaml, ver)
+	return nil
+}
+
+func versionFromChartYaml() (string, error) {
+	chartYaml := filepath.Join(repo.FindRepoRoot(), alluxioChartYaml)
+	contents, err := ioutil.ReadFile(chartYaml)
+	if err != nil {
+		return "", stacktrace.Propagate(err, "error reading %v", chartYaml)
+	}
+	type yamlObj struct {
+		Version string `yaml:"version"`
+	}
+	var chart yamlObj
+	if err := yaml.Unmarshal(contents, &chart); err != nil {
+		return "", stacktrace.Propagate(err, "error unmarshalling %v", alluxioChartYaml)
+	}
+	return chart.Version, nil
+}

--- a/dev/scripts/src/alluxio.org/build/docker.yml
+++ b/dev/scripts/src/alluxio.org/build/docker.yml
@@ -1,0 +1,19 @@
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+alluxio-csi:
+  dockerfile: dev/build/csi/Dockerfile
+  tag: alluxio/csi:${VERSION}
+  targetName: alluxio-csi-${VERSION}-docker.tar
+alluxio-k8s-operator:
+  dockerfile: dev/build/Dockerfile
+  tag: alluxio/k8s-operator:${VERSION}
+  targetName: alluxio-k8s-operator-${VERSION}-docker.tar

--- a/dev/scripts/src/alluxio.org/build/helm.yml
+++ b/dev/scripts/src/alluxio.org/build/helm.yml
@@ -1,0 +1,19 @@
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+alluxio:
+  chartPath: deploy/charts/alluxio
+  targetName: alluxio-${VERSION}.tgz
+  flags: --dependency-update
+alluxio-operator:
+  chartPath: deploy/charts/alluxio-operator
+  targetName: alluxio-operator-${VERSION}.tgz
+  flags: --dependency-update

--- a/dev/scripts/src/alluxio.org/build/main.go
+++ b/dev/scripts/src/alluxio.org/build/main.go
@@ -1,0 +1,46 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/palantir/stacktrace"
+
+	"alluxio.org/build/cmd"
+)
+
+func main() {
+	if err := run(os.Args); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	if len(args) < 2 {
+		return stacktrace.NewError("expected a subcommand argument. select one of the following: %v", cmd.SubCmdNames)
+	}
+	switch subCmd := args[1]; subCmd {
+	case cmd.Docker:
+		return cmd.DockerF(args[2:])
+	case cmd.Helm:
+		return cmd.HelmF(args[2:])
+	case cmd.Presets:
+		return cmd.PresetsF(args[2:])
+	case cmd.Version:
+		return cmd.VersionF()
+	default:
+		return stacktrace.NewError("unknown subcommand %v. select one of the following: %v", subCmd, cmd.SubCmdNames)
+	}
+}

--- a/dev/scripts/src/alluxio.org/build/presets.yml
+++ b/dev/scripts/src/alluxio.org/build/presets.yml
@@ -1,0 +1,25 @@
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+nightly:
+  docker:
+    - --image alluxio-csi --metadata docker:repo=alluxio/alluxio-csi
+    - --image alluxio-k8s-operator --metadata docker:repo=alluxio/alluxio-k8s-operator
+  helm:
+    - --chartName alluxio
+    - --chartName alluxio-operator
+release:
+  docker:
+    - --image alluxio-csi --metadata docker:repo=alluxio/alluxio-csi,docker:setLatest=true
+    - --image alluxio-k8s-operator --metadata docker:repo=alluxio/alluxio-k8s-operator,docker:setLatest=true
+  helm:
+    - --chartName alluxio
+    - --chartName alluxio-operator

--- a/dev/scripts/src/alluxio.org/common/command/command.go
+++ b/dev/scripts/src/alluxio.org/common/command/command.go
@@ -1,0 +1,224 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package command
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/palantir/stacktrace"
+)
+
+const bash = "bash"
+
+// BashBuilder is a builder pattern struct for constructing and executing bash commands
+type BashBuilder struct {
+	// required input
+	cmd string // command to run with bash -c
+
+	// optional inputs
+	context context.Context // run command with given context if provided
+	dir     string          // directory to execute bash command from
+	env     []string        // environment variables to append to current env from os.Environ()
+
+	// output handling
+	ignoreExitError bool      // does not return an error if the returned error is of type *exec.ExitError
+	stderr          io.Writer // streams stderr into given Writer. note this affects the evaluation of the returned error
+	stdout          io.Writer // streams stdout into given Writer
+
+	// outputs
+	ExitError *exec.ExitError // set if the returned error from command execution is of type *exec.ExitError
+}
+
+func New(cmd string) *BashBuilder {
+	return &BashBuilder{
+		cmd: cmd,
+	}
+}
+
+func NewF(format string, args ...interface{}) *BashBuilder {
+	return New(fmt.Sprintf(format, args...))
+}
+
+// CombinedOutput builds the given command, starts and waits for the command to successfully complete
+// It returns the combined contents of stderr and stdout as a []byte
+// The command returns an error if there is a non-zero exit code, unless ignoreExitError is enabled
+func CombinedOutput(cmd string) ([]byte, error) {
+	b := New(cmd)
+	out, err := b.Cmd().CombinedOutput()
+	if err != nil {
+		if handledErr := b.handleExitError(err); handledErr != nil {
+			return nil, stacktrace.Propagate(err, "error running command: %v\nerror: %v", b.String(), string(out))
+		}
+	}
+	return out, nil
+}
+
+// CombinedOutputF executes the formatted string as CombinedOutput()
+func CombinedOutputF(format string, args ...interface{}) ([]byte, error) {
+	return CombinedOutput(fmt.Sprintf(format, args...))
+}
+
+// Output builds the given command, starts and waits for the command to successfully complete
+// It returns the contents of stdout as a []byte
+// The command returns an error if there is any stderr or non-zero exit code, unless ignoreExitError is enabled
+func Output(cmd string) ([]byte, error) {
+	b := New(cmd)
+	out, err := b.Cmd().Output()
+	if err != nil {
+		if handledErr := b.handleExitError(err); handledErr != nil {
+			return nil, stacktrace.Propagate(err, "error running command")
+		}
+	}
+	return out, nil
+}
+
+// OutputF executes the formatted string as Output()
+func OutputF(format string, args ...interface{}) ([]byte, error) {
+	return Output(fmt.Sprintf(format, args...))
+}
+
+// Run builds the given command, starts, and waits for the command to successfully complete
+// The command returns an error if there is any stderr or non-zero exit code, unless ignoreExitError is enabled
+func Run(cmd string) error {
+	b := New(cmd)
+	if out, err := b.Cmd().CombinedOutput(); err != nil {
+		if handledErr := b.handleExitError(err); handledErr != nil {
+			return stacktrace.Propagate(err, "error running command: %v\nerror: %v", b.String(), string(out))
+		}
+	}
+	return nil
+}
+
+// RunF executes the formatted string as Run()
+func RunF(format string, args ...interface{}) error {
+	return Run(fmt.Sprintf(format, args...))
+}
+
+func (b *BashBuilder) Command() string {
+	return b.cmd
+}
+
+func (b *BashBuilder) WithContext(ctx context.Context) *BashBuilder {
+	b.context = ctx
+	return b
+}
+
+func (b *BashBuilder) Env(key string, value interface{}) *BashBuilder {
+	b.env = append(b.env, fmt.Sprintf("%s=%v", key, value))
+	return b
+}
+
+func (b *BashBuilder) IgnoreExitError() *BashBuilder {
+	b.ignoreExitError = true
+	return b
+}
+
+func (b *BashBuilder) SetStderr(stderr io.Writer) *BashBuilder {
+	b.stderr = stderr
+	return b
+}
+
+func (b *BashBuilder) SetStdout(stdout io.Writer) *BashBuilder {
+	b.stdout = stdout
+	return b
+}
+
+func (b *BashBuilder) WithDir(dir string) *BashBuilder {
+	b.dir = dir
+	return b
+}
+
+func (b *BashBuilder) String() string {
+	return b.cmd
+}
+
+func (b *BashBuilder) Cmd() *exec.Cmd {
+	cmdStr := b.cmd
+
+	var ret *exec.Cmd
+	if b.context != nil {
+		ret = exec.CommandContext(b.context, bash, "-c", cmdStr)
+	} else {
+		ret = exec.Command(bash, "-c", cmdStr)
+	}
+	if b.dir != "" {
+		ret.Dir = b.dir
+	}
+	ret.Env = os.Environ()
+	for _, envPv := range b.env {
+		ret.Env = append(ret.Env, envPv)
+	}
+	if b.stderr != nil {
+		ret.Stderr = b.stderr
+	}
+	if b.stdout != nil {
+		ret.Stdout = b.stdout
+	}
+	return ret
+}
+
+// CombinedOutput builds the given command, starts and waits for the command to successfully complete
+// It returns the combined contents of stderr and stdout as a []byte
+// The command returns an error if there is a non-zero exit code, unless ignoreExitError is enabled
+func (b *BashBuilder) CombinedOutput() ([]byte, error) {
+	if b.stdout != nil || b.stderr != nil {
+		return nil, stacktrace.NewError("cannot ask for combined output when stdout or stderr has been set")
+	}
+	combinedOut, err := b.Cmd().CombinedOutput()
+	if err != nil {
+		if handledErr := b.handleExitError(err); handledErr != nil {
+			return nil, stacktrace.Propagate(err, "error running command: %v\n error: %v", b.String(), string(combinedOut))
+		}
+	}
+	return combinedOut, nil
+}
+
+// Output builds the given command, starts and waits for the command to successfully complete
+// It returns the contents of stdout as a []byte
+// The command returns an error if there is any stderr or non-zero exit code, unless ignoreExitError is enabled
+func (b *BashBuilder) Output() ([]byte, error) {
+	if b.stdout != nil {
+		return nil, stacktrace.NewError("cannot ask for output when stdout has been set")
+	}
+	out, err := b.Cmd().Output()
+	if err != nil {
+		if handledErr := b.handleExitError(err); handledErr != nil {
+			return nil, stacktrace.Propagate(err, "error running command")
+		}
+	}
+	return out, nil
+}
+
+// Run builds the given command, starts, and waits for the command to successfully complete
+// The command returns an error if there is any stderr or non-zero exit code, unless ignoreExitError is enabled
+func (b *BashBuilder) Run() error {
+	if err := b.Cmd().Run(); err != nil {
+		if handledErr := b.handleExitError(err); handledErr != nil {
+			return stacktrace.Propagate(err, "error running command")
+		}
+	}
+	return nil
+}
+
+func (b *BashBuilder) handleExitError(err error) error {
+	if ee, ok := err.(*exec.ExitError); ok {
+		b.ExitError = ee
+		if b.ignoreExitError {
+			return nil
+		}
+	}
+	return err
+}

--- a/dev/scripts/src/alluxio.org/common/repo/repo.go
+++ b/dev/scripts/src/alluxio.org/common/repo/repo.go
@@ -1,0 +1,44 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package repo
+
+import (
+	"log"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"github.com/palantir/stacktrace"
+)
+
+var (
+	root         string
+	repoRootOnce sync.Once
+)
+
+func FindRepoRoot() string {
+	repoRootOnce.Do(func() {
+		// navigate 7 parent directories to reach repo root,
+		// assuming this go file is located in <repoRoot>/dev/scripts/src/alluxio.org/common/repo/repo.go
+		const repoRootDepth = 7
+		_, r, _, ok := runtime.Caller(0)
+		if !ok {
+			panic(stacktrace.NewError("error getting call stack to find repo root"))
+		}
+		for i := 0; i < repoRootDepth; i++ {
+			r = filepath.Dir(r)
+		}
+		log.Printf("Repository root at directory: %v", r)
+		root = r
+	})
+	return root
+}

--- a/dev/scripts/src/alluxio.org/go.mod
+++ b/dev/scripts/src/alluxio.org/go.mod
@@ -1,0 +1,10 @@
+module alluxio.org
+
+go 1.18
+
+require (
+	github.com/palantir/stacktrace v0.0.0-20161112013806-78658fd2d177
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require github.com/stretchr/testify v1.8.2 // indirect

--- a/dev/scripts/src/alluxio.org/go.sum
+++ b/dev/scripts/src/alluxio.org/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/palantir/stacktrace v0.0.0-20161112013806-78658fd2d177 h1:nRlQD0u1871kaznCnn1EvYiMbum36v7hw1DLPEjds4o=
+github.com/palantir/stacktrace v0.0.0-20161112013806-78658fd2d177/go.mod h1:ao5zGxj8Z4x60IOVYZUbDSmt3R8Ddo080vEgPosHpak=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Builds helm charts and docker images and saves them in tarballs. Configurable templates at 
- `dev/scripts/src/alluxio.org/build/docker.yml`
- `dev/scripts/src/alluxio.org/build/helm.yml`

usage
```
// docker images
./dev/scripts/build-artifact.sh docker --image alluxio-csi
./dev/scripts/build-artifact.sh docker --image alluxio-k8s-operator

// helm charts
./dev/scripts/build-artifact.sh helm --chartName alluxio
./dev/scripts/build-artifact.sh helm --chartName alluxio-operator
```