### PR TITLE
Fix hostNetwork type

### DIFF
--- a/api/v1alpha1/alluxiocluster_types.go
+++ b/api/v1alpha1/alluxiocluster_types.go
@@ -29,7 +29,7 @@ type AlluxioClusterSpec struct {
 	User               string            `json:"user,omitempty" yaml:"user,omitempty"`
 	Group              string            `json:"group,omitempty" yaml:"group,omitempty"`
 	FsGroup            string            `json:"fsGroup,omitempty" yaml:"fsGroup,omitempty"`
-	HostNetwork        string            `json:"hostNetwork,omitempty" yaml:"hostNetwork,omitempty"`
+	HostNetwork        bool              `json:"hostNetwork,omitempty" yaml:"hostNetwork,omitempty"`
 	DnsPolicy          string            `json:"dnsPolicy,omitempty" yaml:"dnsPolicy,omitempty"`
 	ServiceAccountName string            `json:"serviceAccountName,omitempty" yaml:"serviceAccountName,omitempty"`
 	HostAliases        []HostAlias       `json:"hostAliases,omitempty" yaml:"hostAliases,omitempty"`

--- a/deploy/charts/alluxio-operator/crds/k8s-operator.alluxio.com_alluxioclusters.yaml
+++ b/deploy/charts/alluxio-operator/crds/k8s-operator.alluxio.com_alluxioclusters.yaml
@@ -1022,7 +1022,7 @@ spec:
                   type: object
                 type: array
               hostNetwork:
-                type: string
+                type: boolean
               image:
                 type: string
               imagePullPolicy:

--- a/resources/crds/k8s-operator.alluxio.com_alluxioclusters.yaml
+++ b/resources/crds/k8s-operator.alluxio.com_alluxioclusters.yaml
@@ -1022,7 +1022,7 @@ spec:
                   type: object
                 type: array
               hostNetwork:
-                type: string
+                type: boolean
               image:
                 type: string
               imagePullPolicy:


### PR DESCRIPTION
Fix the type of `hostNetwork`.
Default value of `DnsPolicy`  depends on the bool value of `hostNetwork`. 