### PR TITLE
Add alluxio-monitor into image

### DIFF
--- a/dev/build/Dockerfile
+++ b/dev/build/Dockerfile
@@ -40,6 +40,7 @@ RUN groupadd --gid 1001 k8soperator && \
 WORKDIR /
 
 COPY --chown=1001:1001 ../../deploy/charts/alluxio /opt/charts/alluxio
+COPY --chown=1001:1001 ../../deploy/charts/alluxio-monitor /opt/charts/alluxio-monitor
 COPY --chown=1001:1001 ../../deploy/jobs /opt/alluxio-jobs
 COPY --chown=1001:1001 --from=builder /opt/alluxio-k8s-operator/bin/alluxio-manager .
 COPY --chown=1001:1001 --from=builder /opt/alluxio-k8s-operator/bin/dataset-manager .


### PR DESCRIPTION
Fix Dockerifle build that `helm dependency update` cannot find alluxio-monitor dir.