### PR TITLE
Umount before mount fuse

### DIFF
--- a/api/v1alpha1/alluxiocluster_types.go
+++ b/api/v1alpha1/alluxiocluster_types.go
@@ -26,8 +26,8 @@ type AlluxioClusterSpec struct {
 	ImageTag           string             `json:"imageTag,omitempty" yaml:"imageTag,omitempty"`
 	ImagePullPolicy    string             `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
 	ImagePullSecrets   []string           `json:"imagePullSecrets,omitempty" yaml:"imagePullSecrets,omitempty"`
-	User               string             `json:"user,omitempty" yaml:"user,omitempty"`
-	Group              string             `json:"group,omitempty" yaml:"group,omitempty"`
+	User               *int               `json:"user,omitempty" yaml:"user,omitempty"`
+	Group              *int               `json:"group,omitempty" yaml:"group,omitempty"`
 	FsGroup            string             `json:"fsGroup,omitempty" yaml:"fsGroup,omitempty"`
 	HostNetwork        bool               `json:"hostNetwork,omitempty" yaml:"hostNetwork,omitempty"`
 	DnsPolicy          string             `json:"dnsPolicy,omitempty" yaml:"dnsPolicy,omitempty"`
@@ -140,14 +140,14 @@ type FuseSpec struct {
 	Affinity       corev1.Affinity   `json:"affinity,omitempty" yaml:"affinity,omitempty"`
 	Enabled        bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 	Env            map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
-	Group          string            `json:"group,omitempty" yaml:"group,omitempty"`
+	Group          *int              `json:"group,omitempty" yaml:"group,omitempty"`
 	JvmOptions     []string          `json:"jvmOptions,omitempty" yaml:"jvmOptions,omitempty"`
 	MountOptions   []string          `json:"mountOptions,omitempty" yaml:"mountOptions,omitempty"`
 	NodeSelector   map[string]string `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty"`
 	PodAnnotations map[string]string `json:"podAnnotations,omitempty" yaml:"podAnnotations,omitempty"`
 	Resources      ResourcesSpec     `json:"resources,omitempty" yaml:"resources,omitempty"`
 	Tolerations    []Toleration      `json:"tolerations,omitempty" yaml:"tolerations,omitempty"`
-	User           string            `json:"user,omitempty" yaml:"user,omitempty"`
+	User           *int              `json:"user,omitempty" yaml:"user,omitempty"`
 }
 
 type ControllerPluginSpec struct {

--- a/api/v1alpha1/alluxiocluster_types.go
+++ b/api/v1alpha1/alluxiocluster_types.go
@@ -140,12 +140,14 @@ type FuseSpec struct {
 	Affinity       corev1.Affinity   `json:"affinity,omitempty" yaml:"affinity,omitempty"`
 	Enabled        bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 	Env            map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
+	Group          string            `json:"group,omitempty" yaml:"group,omitempty"`
 	JvmOptions     []string          `json:"jvmOptions,omitempty" yaml:"jvmOptions,omitempty"`
 	MountOptions   []string          `json:"mountOptions,omitempty" yaml:"mountOptions,omitempty"`
 	NodeSelector   map[string]string `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty"`
 	PodAnnotations map[string]string `json:"podAnnotations,omitempty" yaml:"podAnnotations,omitempty"`
 	Resources      ResourcesSpec     `json:"resources,omitempty" yaml:"resources,omitempty"`
 	Tolerations    []Toleration      `json:"tolerations,omitempty" yaml:"tolerations,omitempty"`
+	User           string            `json:"user,omitempty" yaml:"user,omitempty"`
 }
 
 type ControllerPluginSpec struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -87,6 +87,16 @@ func (in *AlluxioClusterSpec) DeepCopyInto(out *AlluxioClusterSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.User != nil {
+		in, out := &in.User, &out.User
+		*out = new(int)
+		**out = **in
+	}
+	if in.Group != nil {
+		in, out := &in.Group, &out.Group
+		*out = new(int)
+		**out = **in
+	}
 	if in.HostAliases != nil {
 		in, out := &in.HostAliases, &out.HostAliases
 		*out = make([]HostAlias, len(*in))
@@ -389,6 +399,11 @@ func (in *FuseSpec) DeepCopyInto(out *FuseSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Group != nil {
+		in, out := &in.Group, &out.Group
+		*out = new(int)
+		**out = **in
+	}
 	if in.JvmOptions != nil {
 		in, out := &in.JvmOptions, &out.JvmOptions
 		*out = make([]string, len(*in))
@@ -418,6 +433,11 @@ func (in *FuseSpec) DeepCopyInto(out *FuseSpec) {
 		in, out := &in.Tolerations, &out.Tolerations
 		*out = make([]Toleration, len(*in))
 		copy(*out, *in)
+	}
+	if in.User != nil {
+		in, out := &in.User, &out.User
+		*out = new(int)
+		**out = **in
 	}
 }
 

--- a/deploy/charts/alluxio-operator/crds/k8s-operator.alluxio.com_alluxioclusters.yaml
+++ b/deploy/charts/alluxio-operator/crds/k8s-operator.alluxio.com_alluxioclusters.yaml
@@ -958,6 +958,8 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  group:
+                    type: string
                   jvmOptions:
                     items:
                       type: string
@@ -1009,6 +1011,8 @@ spec:
                       - value
                       type: object
                     type: array
+                  user:
+                    type: string
                 type: object
               group:
                 type: string

--- a/deploy/charts/alluxio-operator/crds/k8s-operator.alluxio.com_alluxioclusters.yaml
+++ b/deploy/charts/alluxio-operator/crds/k8s-operator.alluxio.com_alluxioclusters.yaml
@@ -959,7 +959,7 @@ spec:
                       type: string
                     type: object
                   group:
-                    type: string
+                    type: integer
                   jvmOptions:
                     items:
                       type: string
@@ -1012,10 +1012,10 @@ spec:
                       type: object
                     type: array
                   user:
-                    type: string
+                    type: integer
                 type: object
               group:
-                type: string
+                type: integer
               hostAliases:
                 items:
                   properties:
@@ -3114,7 +3114,7 @@ spec:
                   type: object
                 type: array
               user:
-                type: string
+                type: integer
               worker:
                 properties:
                   affinity:

--- a/deploy/charts/alluxio/templates/fuse/daemonset.yaml
+++ b/deploy/charts/alluxio/templates/fuse/daemonset.yaml
@@ -142,6 +142,8 @@ spec:
               value: "{{ $value }}"
             {{- end }}
           securityContext:
+            runAsUser: {{ .Values.fuse.user }}
+            runAsGroup: {{ .Values.fuse.group }}
             privileged: true # required by bidirectional mount
           lifecycle:
             preStop:

--- a/deploy/charts/alluxio/templates/fuse/daemonset.yaml
+++ b/deploy/charts/alluxio/templates/fuse/daemonset.yaml
@@ -74,8 +74,8 @@ spec:
 {{ toYaml .Values.tolerations | trim | indent 8  }}
       {{- end }}
       securityContext:
-        runAsUser: {{ .Values.user }}
-        runAsGroup: {{ .Values.group }}
+        runAsUser: {{ .Values.fuse.user }}
+        runAsGroup: {{ .Values.fuse.group }}
         fsGroup: {{ .Values.fsGroup }}
       {{- if .Values.serviceAccountName }}
       serviceAccountName: {{ .Values.serviceAccountName }}
@@ -92,7 +92,7 @@ spec:
             runAsGroup: 0
           command: [ "chown", "-R" ]
           args:
-            - {{ .Values.user }}:{{ .Values.group }}
+            - {{ .Values.fuse.user }}:{{ .Values.fuse.group }}
             - {{ $hostMountPath }}
             {{- if .Values.hostPathForLogging }}
             - {{ $alluxioFuseLogDir }}
@@ -104,6 +104,13 @@ spec:
             - name: {{ $alluxioFuseLogVolumeName }}
               mountPath: {{ $alluxioFuseLogDir }}
             {{- end }}
+        - name: create-alluxio-fuse-dir
+          image: {{ .Values.image }}:{{ .Values.imageTag }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command: [ "mkdir", "-p", {{ $alluxioFuseMountPoint }}]
+          volumeMounts:
+            - name: alluxio-fuse-mount
+              mountPath: {{ $hostMountPath }}
         - name: wait-master
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           command: ["/bin/sh", "-c"]
@@ -121,14 +128,10 @@ spec:
           {{- if .Values.fuse.resources }}
 {{ include "alluxio.resources" .Values.fuse.resources | indent 10 }}
           {{- end }}
-          command: ["/entrypoint.sh"]
+          command: ["/bin/sh", "-c"]
           args:
-            - fuse
-            - {{ required "The path of the dataset must be set." .Values.dataset.path }}
-            - {{ $alluxioFuseMountPoint }}
-            {{- range .Values.fuse.mountOptions }}
-            - -o {{ . }}
-            {{- end }}
+            - umount -l {{ $alluxioFuseMountPoint }};
+              /entrypoint.sh fuse {{ required "The path of the dataset must be set." .Values.dataset.path }} {{ $alluxioFuseMountPoint }} {{- range .Values.fuse.mountOptions }} -o {{ . }} {{- end }}
           env:
             - name: ALLUXIO_CLIENT_HOSTNAME
               valueFrom:
@@ -143,7 +146,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/opt/alluxio/integration/fuse/bin/alluxio-fuse", "unmount", {{ $alluxioFuseMountPoint }}]
+                command: ["fusermount", "-u", {{ $alluxioFuseMountPoint }}]
           volumeMounts:
             - name: alluxio-fuse-mount
               mountPath: {{ $hostMountPath }}

--- a/deploy/charts/alluxio/values.yaml
+++ b/deploy/charts/alluxio/values.yaml
@@ -298,6 +298,9 @@ fuse:
   enabled: false
   # The path on the host machine for storing fuse log
   hostPathForLogs: /mnt/alluxio/logs/fuse
+  # User and Group that override the global value
+  user: 1000
+  group: 1000
   # Extra environment variables for the Alluxio fuse pods. Format:
   # env:
   #   <key1>: <value1>

--- a/resources/crds/k8s-operator.alluxio.com_alluxioclusters.yaml
+++ b/resources/crds/k8s-operator.alluxio.com_alluxioclusters.yaml
@@ -958,6 +958,8 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  group:
+                    type: string
                   jvmOptions:
                     items:
                       type: string
@@ -1009,6 +1011,8 @@ spec:
                       - value
                       type: object
                     type: array
+                  user:
+                    type: string
                 type: object
               group:
                 type: string

--- a/resources/crds/k8s-operator.alluxio.com_alluxioclusters.yaml
+++ b/resources/crds/k8s-operator.alluxio.com_alluxioclusters.yaml
@@ -959,7 +959,7 @@ spec:
                       type: string
                     type: object
                   group:
-                    type: string
+                    type: integer
                   jvmOptions:
                     items:
                       type: string
@@ -1012,10 +1012,10 @@ spec:
                       type: object
                     type: array
                   user:
-                    type: string
+                    type: integer
                 type: object
               group:
-                type: string
+                type: integer
               hostAliases:
                 items:
                   properties:
@@ -3114,7 +3114,7 @@ spec:
                   type: object
                 type: array
               user:
-                type: string
+                type: integer
               worker:
                 properties:
                   affinity:

--- a/tests/helm/expectedTemplates/fuse/daemonset.yaml
+++ b/tests/helm/expectedTemplates/fuse/daemonset.yaml
@@ -112,6 +112,13 @@ spec:
               mountPath: /mnt/alluxio
             - name: dummy-alluxio-fuse-log-volume
               mountPath: /opt/alluxio/logs
+        - name: create-alluxio-fuse-dir
+          image: dummy/dummy:dummy
+          imagePullPolicy: IfNotPresent
+          command: [ "mkdir", "-p", /mnt/alluxio/fuse]
+          volumeMounts:
+            - name: alluxio-fuse-mount
+              mountPath: /mnt/alluxio
         - name: wait-master
           image: dummy/dummy:dummy
           command: ["/bin/sh", "-c"]
@@ -133,14 +140,10 @@ spec:
             requests:
               cpu: 0.5
               memory: 1Gi
-          command: ["/entrypoint.sh"]
+          command: ["/bin/sh", "-c"]
           args:
-            - fuse
-            - /dummy/dataset/path
-            - /mnt/alluxio/fuse
-            - -o allow_other
-            - -o entry_timeout=3600
-            - -o attr_timeout=3600
+            - umount -l /mnt/alluxio/fuse;
+              /entrypoint.sh fuse /dummy/dataset/path /mnt/alluxio/fuse -o allow_other -o entry_timeout=3600 -o attr_timeout=3600
           env:
             - name: ALLUXIO_CLIENT_HOSTNAME
               valueFrom:
@@ -155,7 +158,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/opt/alluxio/integration/fuse/bin/alluxio-fuse", "unmount", /mnt/alluxio/fuse]
+                command: ["fusermount", "-u", /mnt/alluxio/fuse]
           volumeMounts:
             - name: alluxio-fuse-mount
               mountPath: /mnt/alluxio

--- a/tests/helm/expectedTemplates/fuse/daemonset.yaml
+++ b/tests/helm/expectedTemplates/fuse/daemonset.yaml
@@ -154,6 +154,8 @@ spec:
             - name: "fuseEnvKey2"
               value: "fuseEnvVal2"
           securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
             privileged: true # required by bidirectional mount
           lifecycle:
             preStop:


### PR DESCRIPTION
If Fuse container OOM'd, the pre-stop hook is not guaranteed to be executed, so we need a way to clean up the mount point so that users don't need to do that manually (log into the host machine and run sudo umount). User root is needed for calling umount before mounting.

Old behavior: no matter root or non-root, if there's OOM, fuse container cannot restart.

New behavior:
If not using root and there's no OOM, everything works as before. If there is OOM, umount line will error out and fuse container cannot restart.
If using root and there is OOM, fuse container can restart normally.