### PR TITLE
fix fuse dnsPolicy

### DIFF
--- a/deploy/charts/alluxio/templates/fuse/daemonset.yaml
+++ b/deploy/charts/alluxio/templates/fuse/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
       {{- end }}
     spec:
       hostNetwork: {{ .Values.hostNetwork }}
-      dnsPolicy: {{ .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | default (.Values.hostNetwork | ternary "ClusterFirstWithHostNet" "ClusterFirst") }}
       nodeSelector:
       {{- if .Values.fuse.nodeSelector }}
 {{ toYaml .Values.fuse.nodeSelector | trim | indent 8  }}


### PR DESCRIPTION
If `hostNetwork` is set to true, by default we shall use `ClusterFirstWithHostNet`