### PR TITLE
Fix path permission

### DIFF
--- a/deploy/charts/alluxio/templates/fuse/daemonset.yaml
+++ b/deploy/charts/alluxio/templates/fuse/daemonset.yaml
@@ -92,7 +92,7 @@ spec:
             runAsGroup: 0
           command: [ "chown", "-R" ]
           args:
-            - {{ .Values.fuse.user }}:{{ .Values.fuse.group }}
+            - {{ .Values.user }}:{{ .Values.group }}
             - {{ $hostMountPath }}
             {{- if .Values.hostPathForLogging }}
             - {{ $alluxioFuseLogDir }}
@@ -142,8 +142,6 @@ spec:
               value: "{{ $value }}"
             {{- end }}
           securityContext:
-            runAsUser: {{ .Values.fuse.user }}
-            runAsGroup: {{ .Values.fuse.group }}
             privileged: true # required by bidirectional mount
           lifecycle:
             preStop:

--- a/tests/helm/expectedTemplates/fuse/daemonset.yaml
+++ b/tests/helm/expectedTemplates/fuse/daemonset.yaml
@@ -154,8 +154,6 @@ spec:
             - name: "fuseEnvKey2"
               value: "fuseEnvVal2"
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
             privileged: true # required by bidirectional mount
           lifecycle:
             preStop:


### PR DESCRIPTION
In the case where fuse user and group is set to root, we would chown the whole `/mnt/alluxio` to user root, which will make the co-located master/worker fail to even start.

Now we chown `/mnt/alluxio` to the global user. The next initContainer will create the mount point based on the fuse user, so the mount will work.