### PR TITLE
Worker Identity

### DIFF
--- a/deploy/charts/alluxio/templates/helpers/_alluxio-site-properties.tpl
+++ b/deploy/charts/alluxio/templates/helpers/_alluxio-site-properties.tpl
@@ -47,7 +47,7 @@ alluxio.worker.page.store.dirs={{ .Values.pagestore.hostPath }}
 {{ printf "alluxio.worker.page.store.sizes=%v" .Values.pagestore.quota }}
 
 # Worker Identity
-{{ printf "alluxio.worker.identity.uuid.file.path=%v/worker_identiy" include "alluxio.mount.basePath" "/worker_identity" }}
+{{ printf "alluxio.worker.identity.uuid.file.path=%v/worker_identity" (include "alluxio.mount.basePath" "/worker_identity") }}
 
 {{- if .Values.etcd.enabled }}
 alluxio.worker.membership.manager.type=ETCD

--- a/deploy/charts/alluxio/templates/helpers/_alluxio-site-properties.tpl
+++ b/deploy/charts/alluxio/templates/helpers/_alluxio-site-properties.tpl
@@ -46,6 +46,9 @@ alluxio.worker.page.store.type=LOCAL
 alluxio.worker.page.store.dirs={{ .Values.pagestore.hostPath }}
 {{ printf "alluxio.worker.page.store.sizes=%v" .Values.pagestore.quota }}
 
+# Worker Identity
+{{ printf "alluxio.worker.identity.uuid.file.path=%v/worker_identiy" include "alluxio.mount.basePath" "/worker_identity" }}
+
 {{- if .Values.etcd.enabled }}
 alluxio.worker.membership.manager.type=ETCD
 {{ printf "alluxio.etcd.endpoints=http://%v-etcd:%v" .Release.Name .Values.etcd.containerPorts.client }}

--- a/deploy/charts/alluxio/templates/helpers/_alluxio-site-properties.tpl
+++ b/deploy/charts/alluxio/templates/helpers/_alluxio-site-properties.tpl
@@ -47,7 +47,7 @@ alluxio.worker.page.store.dirs={{ .Values.pagestore.hostPath }}
 {{ printf "alluxio.worker.page.store.sizes=%v" .Values.pagestore.quota }}
 
 # Worker Identity
-{{ printf "alluxio.worker.identity.uuid.file.path=%v/worker_identity" (include "alluxio.mount.basePath" "/worker_identity") }}
+{{ printf "alluxio.worker.identity.uuid.file.path=%v/worker_identity" (include "alluxio.mount.basePath" "/system-info") }}
 
 {{- if .Values.etcd.enabled }}
 alluxio.worker.membership.manager.type=ETCD

--- a/deploy/charts/alluxio/templates/worker/deployment.yaml
+++ b/deploy/charts/alluxio/templates/worker/deployment.yaml
@@ -18,8 +18,8 @@
 {{- $alluxioWorkerLogVolumeName := include "alluxio.getVolumeName" (dict "prefix" $fullName "component" "worker-log") }}
 {{- $alluxioWorkerPagestorePath := include "alluxio.mount.basePath" "/pagestore" }}
 {{- $alluxioWorkerLogDir := include "alluxio.basePath" "/logs"}}
-{{- $alluxioWorkerIdVolumeName := include "alluxio.getVolumeName" (dict "prefix" $fullName "component" "worker-identity") }}
-{{- $alluxioWorkerIdDirPath := include "alluxio.mount.basePath" "/worker_identity" }}
+{{- $alluxioWorkerSysInfoVolumeName := include "alluxio.getVolumeName" (dict "prefix" $fullName "component" "system-info") }}
+{{- $alluxioWorkerSysInfoDirPath := include "alluxio.mount.basePath" "/system-info" }}
 
 {{- define "pagestoreHostPathVolumes" -}}
 {{- $paths := splitList "," .Values.pagestore.hostPath }}
@@ -133,6 +133,7 @@ spec:
         command: [ "chown", "-R" ]
         args:
           - {{ .Values.user }}:{{ .Values.group }}
+          - {{ $alluxioWorkerSysInfoDirPath }}
           {{- if .Values.hostPathForLogging }}
           - {{ $alluxioWorkerLogDir }}
           {{- end }}
@@ -143,6 +144,8 @@ spec:
           {{- end }}
           {{- end }}
         volumeMounts:
+          - name: {{ $alluxioWorkerSysInfoVolumeName }}
+            mountPath: {{ $alluxioWorkerSysInfoDirPath }}
           {{- if .Values.hostPathForLogging }}
           - name: {{ $alluxioWorkerLogVolumeName }}
             mountPath: {{ $alluxioWorkerLogDir }}
@@ -211,8 +214,8 @@ spec:
           volumeMounts:
             - name: {{ $fullName }}-alluxio-conf
               mountPath: /opt/alluxio/conf
-            - name: {{ $alluxioWorkerIdVolumeName }}
-              mountPath: {{ $alluxioWorkerIdDirPath }}
+            - name: {{ $alluxioWorkerSysInfoVolumeName }}
+              mountPath: {{ $alluxioWorkerSysInfoDirPath }}
             {{- if .Values.hostPathForLogging }}
             - name: {{ $alluxioWorkerLogVolumeName }}
               mountPath: {{ $alluxioWorkerLogDir }}
@@ -241,9 +244,9 @@ spec:
         - name: {{ $fullName }}-alluxio-conf
           configMap:
             name: {{ $fullName }}-alluxio-conf
-        - name: {{ $alluxioWorkerIdVolumeName }}
+        - name: {{ $alluxioWorkerSysInfoVolumeName }}
           hostPath:
-            path: {{ $alluxioWorkerIdDirPath }}
+            path: {{ $alluxioWorkerSysInfoDirPath }}
             type: DirectoryOrCreate
         {{- if .Values.hostPathForLogging }}
         - name: {{ $alluxioWorkerLogVolumeName }}

--- a/deploy/charts/alluxio/templates/worker/deployment.yaml
+++ b/deploy/charts/alluxio/templates/worker/deployment.yaml
@@ -18,6 +18,8 @@
 {{- $alluxioWorkerLogVolumeName := include "alluxio.getVolumeName" (dict "prefix" $fullName "component" "worker-log") }}
 {{- $alluxioWorkerPagestorePath := include "alluxio.mount.basePath" "/pagestore" }}
 {{- $alluxioWorkerLogDir := include "alluxio.basePath" "/logs"}}
+{{- $alluxioWorkerIdVolumeName := include "alluxio.getVolumeName" (dict "prefix" $fullName "component" "worker_identity") }}
+{{- $alluxioWorkerIdDirPath := include "alluxio.mount.basePath" "/worker_identity" }}
 
 {{- define "pagestoreHostPathVolumes" -}}
 {{- $paths := splitList "," .Values.pagestore.hostPath }}
@@ -209,6 +211,8 @@ spec:
           volumeMounts:
             - name: {{ $fullName }}-alluxio-conf
               mountPath: /opt/alluxio/conf
+            - name: {{ $alluxioWorkerIdVolumeName }}
+              mountPath: {{ $alluxioWorkerIdDirPath }}
             {{- if .Values.hostPathForLogging }}
             - name: {{ $alluxioWorkerLogVolumeName }}
               mountPath: {{ $alluxioWorkerLogDir }}
@@ -237,6 +241,10 @@ spec:
         - name: {{ $fullName }}-alluxio-conf
           configMap:
             name: {{ $fullName }}-alluxio-conf
+        - name: {{ $alluxioWorkerIdVolumeName }}
+          hostPath:
+            path: {{ $alluxioWorkerIdDirPath }}
+            type: DirectoryOrCreate
         {{- if .Values.hostPathForLogging }}
         - name: {{ $alluxioWorkerLogVolumeName }}
           hostPath:

--- a/deploy/charts/alluxio/templates/worker/deployment.yaml
+++ b/deploy/charts/alluxio/templates/worker/deployment.yaml
@@ -18,7 +18,7 @@
 {{- $alluxioWorkerLogVolumeName := include "alluxio.getVolumeName" (dict "prefix" $fullName "component" "worker-log") }}
 {{- $alluxioWorkerPagestorePath := include "alluxio.mount.basePath" "/pagestore" }}
 {{- $alluxioWorkerLogDir := include "alluxio.basePath" "/logs"}}
-{{- $alluxioWorkerIdVolumeName := include "alluxio.getVolumeName" (dict "prefix" $fullName "component" "worker_identity") }}
+{{- $alluxioWorkerIdVolumeName := include "alluxio.getVolumeName" (dict "prefix" $fullName "component" "worker-identity") }}
 {{- $alluxioWorkerIdDirPath := include "alluxio.mount.basePath" "/worker_identity" }}
 
 {{- define "pagestoreHostPathVolumes" -}}

--- a/tests/helm/expectedTemplates/conf/configmap.yaml
+++ b/tests/helm/expectedTemplates/conf/configmap.yaml
@@ -47,7 +47,7 @@ data:
     alluxio.worker.page.store.sizes=1Gi
     
     # Worker Identity
-    alluxio.worker.identity.uuid.file.path=/mnt/alluxio/worker_identity/worker_identity
+    alluxio.worker.identity.uuid.file.path=/mnt/alluxio/system-info/worker_identity
   alluxio-env.sh: |-
     ALLUXIO_MASTER_JAVA_OPTS+="-Dalluxio.master.hostname=${ALLUXIO_MASTER_HOSTNAME} masterJvmOption1 masterJvmOption2 "
     ALLUXIO_WORKER_JAVA_OPTS+="-Dalluxio.worker.hostname=${ALLUXIO_WORKER_HOSTNAME} workerJvmOption1 workerJvmOption2 "

--- a/tests/helm/expectedTemplates/conf/configmap.yaml
+++ b/tests/helm/expectedTemplates/conf/configmap.yaml
@@ -45,6 +45,9 @@ data:
     alluxio.worker.page.store.type=LOCAL
     alluxio.worker.page.store.dirs=/mnt/alluxio/pagestore
     alluxio.worker.page.store.sizes=1Gi
+    
+    # Worker Identity
+    alluxio.worker.identity.uuid.file.path=/mnt/alluxio/worker_identity/worker_identity
   alluxio-env.sh: |-
     ALLUXIO_MASTER_JAVA_OPTS+="-Dalluxio.master.hostname=${ALLUXIO_MASTER_HOSTNAME} masterJvmOption1 masterJvmOption2 "
     ALLUXIO_WORKER_JAVA_OPTS+="-Dalluxio.worker.hostname=${ALLUXIO_WORKER_HOSTNAME} workerJvmOption1 workerJvmOption2 "

--- a/tests/helm/expectedTemplates/worker/deployment.yaml
+++ b/tests/helm/expectedTemplates/worker/deployment.yaml
@@ -192,7 +192,7 @@ spec:
           volumeMounts:
             - name: dummy-alluxio-alluxio-conf
               mountPath: /opt/alluxio/conf
-            - name: dummy-alluxio-worker_identity-volume
+            - name: dummy-alluxio-worker-identity-volume
               mountPath: /mnt/alluxio/worker_identity
             - name: dummy-alluxio-worker-log-volume
               mountPath: /opt/alluxio/logs
@@ -223,7 +223,7 @@ spec:
         - name: dummy-alluxio-alluxio-conf
           configMap:
             name: dummy-alluxio-alluxio-conf
-        - name: dummy-alluxio-worker_identity-volume
+        - name: dummy-alluxio-worker-identity-volume
           hostPath:
             path: /mnt/alluxio/worker_identity
             type: DirectoryOrCreate

--- a/tests/helm/expectedTemplates/worker/deployment.yaml
+++ b/tests/helm/expectedTemplates/worker/deployment.yaml
@@ -127,8 +127,11 @@ spec:
         command: [ "chown", "-R" ]
         args:
           - 1000:1000
+          - /mnt/alluxio/system-info
           - /opt/alluxio/logs
         volumeMounts:
+          - name: dummy-alluxio-system-info-volume
+            mountPath: /mnt/alluxio/system-info
           - name: dummy-alluxio-worker-log-volume
             mountPath: /opt/alluxio/logs
       - name: wait-master
@@ -192,8 +195,8 @@ spec:
           volumeMounts:
             - name: dummy-alluxio-alluxio-conf
               mountPath: /opt/alluxio/conf
-            - name: dummy-alluxio-worker-identity-volume
-              mountPath: /mnt/alluxio/worker_identity
+            - name: dummy-alluxio-system-info-volume
+              mountPath: /mnt/alluxio/system-info
             - name: dummy-alluxio-worker-log-volume
               mountPath: /opt/alluxio/logs
             - mountPath: /mnt/alluxio/pagestore
@@ -223,9 +226,9 @@ spec:
         - name: dummy-alluxio-alluxio-conf
           configMap:
             name: dummy-alluxio-alluxio-conf
-        - name: dummy-alluxio-worker-identity-volume
+        - name: dummy-alluxio-system-info-volume
           hostPath:
-            path: /mnt/alluxio/worker_identity
+            path: /mnt/alluxio/system-info
             type: DirectoryOrCreate
         - name: dummy-alluxio-worker-log-volume
           hostPath:

--- a/tests/helm/expectedTemplates/worker/deployment.yaml
+++ b/tests/helm/expectedTemplates/worker/deployment.yaml
@@ -192,6 +192,8 @@ spec:
           volumeMounts:
             - name: dummy-alluxio-alluxio-conf
               mountPath: /opt/alluxio/conf
+            - name: dummy-alluxio-worker_identity-volume
+              mountPath: /mnt/alluxio/worker_identity
             - name: dummy-alluxio-worker-log-volume
               mountPath: /opt/alluxio/logs
             - mountPath: /mnt/alluxio/pagestore
@@ -221,6 +223,10 @@ spec:
         - name: dummy-alluxio-alluxio-conf
           configMap:
             name: dummy-alluxio-alluxio-conf
+        - name: dummy-alluxio-worker_identity-volume
+          hostPath:
+            path: /mnt/alluxio/worker_identity
+            type: DirectoryOrCreate
         - name: dummy-alluxio-worker-log-volume
           hostPath:
             path: /mnt/alluxio/logs/worker


### PR DESCRIPTION
Create a default directory on host machine and mount into worker pods. Worker will then write its identity file into this directory so that it can be persisted in k8s env.