### PR TITLE
Persist worker metadata by default

### DIFF
--- a/deploy/charts/alluxio/templates/helpers/_alluxio-site-properties.tpl
+++ b/deploy/charts/alluxio/templates/helpers/_alluxio-site-properties.tpl
@@ -50,7 +50,7 @@ alluxio.worker.page.store.dirs={{ .Values.pagestore.hostPath }}
 {{ printf "alluxio.worker.identity.uuid.file.path=%v/worker_identity" (include "alluxio.mount.basePath" "/system-info") }}
 
 # Metastore
-alluxio.dora.worker.metastore.rocksdb.dir={{ .Values.metastore.hostPath }}
+alluxio.dora.worker.metastore.rocksdb.dir={{ include "alluxio.mount.basePath" "/metastore" }}
 
 {{- if .Values.etcd.enabled }}
 alluxio.worker.membership.manager.type=ETCD

--- a/deploy/charts/alluxio/templates/helpers/_alluxio-site-properties.tpl
+++ b/deploy/charts/alluxio/templates/helpers/_alluxio-site-properties.tpl
@@ -49,6 +49,9 @@ alluxio.worker.page.store.dirs={{ .Values.pagestore.hostPath }}
 # Worker Identity
 {{ printf "alluxio.worker.identity.uuid.file.path=%v/worker_identity" (include "alluxio.mount.basePath" "/system-info") }}
 
+# Metastore
+alluxio.dora.worker.metastore.rocksdb.dir={{ .Values.metastore.hostPath }}
+
 {{- if .Values.etcd.enabled }}
 alluxio.worker.membership.manager.type=ETCD
 {{ printf "alluxio.etcd.endpoints=http://%v-etcd:%v" .Release.Name .Values.etcd.containerPorts.client }}

--- a/deploy/charts/alluxio/templates/worker/deployment.yaml
+++ b/deploy/charts/alluxio/templates/worker/deployment.yaml
@@ -137,6 +137,7 @@ spec:
           {{- if .Values.hostPathForLogging }}
           - {{ $alluxioWorkerLogDir }}
           {{- end }}
+          - {{ include "alluxio.mount.basePath" "/metastore"}}
           {{- if eq .Values.pagestore.type "hostPath" }}
           {{- $paths := splitList "," .Values.pagestore.hostPath }}
           {{- range $i, $path := $paths }}
@@ -150,6 +151,8 @@ spec:
           - name: {{ $alluxioWorkerLogVolumeName }}
             mountPath: {{ $alluxioWorkerLogDir }}
           {{- end }}
+          - name: {{ $metastoreVolumeName }}
+            mountPath: {{ include "alluxio.mount.basePath" "/metastore" }}
           {{- if eq .Values.pagestore.type "hostPath" }}
 {{- include "pagestoreHostPathVolumeMounts" . | indent 10 }}
           {{- end }}
@@ -228,10 +231,8 @@ spec:
             - mountPath: {{ $alluxioWorkerPagestorePath }}
               name: {{ $pagestoreVolumeName }}
             {{- end }}
-            {{- if .Values.metastore.enabled }}
             - name: {{ $metastoreVolumeName }}
               mountPath: {{ include "alluxio.mount.basePath" "/metastore"}}
-            {{- end }}
             {{- if .Values.secrets }}
 {{- include "alluxio.volumeMounts" (dict "volumeMounts" .Values.secrets.worker "readOnly" true) | indent 12 }}
             {{- end }}
@@ -256,11 +257,15 @@ spec:
             path: {{ .Values.worker.hostPathForLogs }}
             type: DirectoryOrCreate
         {{- end }}
-        {{- if .Values.metastore.enabled }}
         - name: {{ $metastoreVolumeName }}
+          {{- if eq .Values.metastore.type "hostPath "}}
+          hostPath:
+            path: {{ .Values.metastore.hostPath }}
+            type: DirectoryOrCreate
+          {{- else if eq .Values.metastore.type "persistentVolumeClaim" }}
           persistentVolumeClaim:
             claimName: {{ include "alluxio.getPvcName" (dict "prefix" $fullName "component" "metastore") }}
-        {{- end }}
+          {{- end }}
         {{- if .Values.secrets }}
 {{- include "alluxio.secretVolumes" .Values.secrets.worker | indent 8 }}
         {{- end }}

--- a/deploy/charts/alluxio/templates/worker/deployment.yaml
+++ b/deploy/charts/alluxio/templates/worker/deployment.yaml
@@ -258,7 +258,7 @@ spec:
             type: DirectoryOrCreate
         {{- end }}
         - name: {{ $metastoreVolumeName }}
-          {{- if eq .Values.metastore.type "hostPath "}}
+          {{- if eq .Values.metastore.type "hostPath" }}
           hostPath:
             path: {{ .Values.metastore.hostPath }}
             type: DirectoryOrCreate

--- a/deploy/charts/alluxio/templates/worker/metastore-pvc.yaml
+++ b/deploy/charts/alluxio/templates/worker/metastore-pvc.yaml
@@ -13,7 +13,7 @@
 {{- $fullName := include "alluxio.fullname" . }}
 {{- $chart := include "alluxio.chart" . }}
 
-{{- if .Values.metastore.enabled }}
+{{- if eq .Values.metastore.type "persistentVolumeClaim" }}
 {{- $pvcName := include "alluxio.getPvcName" (dict "prefix" $fullName "component" "metastore") }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/deploy/charts/alluxio/values.yaml
+++ b/deploy/charts/alluxio/values.yaml
@@ -247,14 +247,15 @@ pagestore:
     # Requireid for volume type of emptyDir, ignored otherwise
     memoryBacked: false
 
-# Metastore configures ROCKS DB to store metadata on workers instead of using heap.
-# Persistent Volume are required for metastore. Only ReadWriteOnce is supported.
+# Metastore configures ROCKS DB to store metadata on workers
 metastore:
-  # Whether metastore on worker is enabled.
-  enabled: false
-  # Size of requested storage capacity for the persistentVolumeClaim for metastore.
-  size: 1Gi
-  # StorageClass of the Persistent Volume for metastore
+  # Type of the volume for Alluxio worker Metastore. Can be persistentVolumeClaim or hostPath.
+  type: hostPath
+  # Size of the metastore. Required for volume type of persistentVolumeClaim, ignored otherwise
+  size: 256Mi
+  # Required for volume type of hostPath, ignored otherwise
+  hostPath: /mnt/alluxio/metastore
+  # Required for volume type of persistentVolumeClaim, ignored otherwise
   storageClass: "standard"
 
 

--- a/tests/helm/config_test.yaml
+++ b/tests/helm/config_test.yaml
@@ -370,13 +370,14 @@ pagestore:
     memoryBacked: false
 
 # Metastore configures ROCKS DB to store metadata on workers instead of using heap.
-# Persistent Volume are required for metastore. Only ReadWriteOnce is supported.
 metastore:
-  # Whether metastore on worker is enabled.
-  enabled: true
-  # Size of requested storage capacity for the persistentVolumeClaim for metastore.
-  size: 1Gi
-  # StorageClass of the Persistent Volume for metastore
+  # Type of the volume for Alluxio worker Metastore. Can be persistentVolumeClaim or hostPath.
+  type: persistentVolumeClaim
+  # Size of the metastore. Required for volume type of persistentVolumeClaim, ignored otherwise
+  size: 256Mi
+  # Required for volume type of hostPath, ignored otherwise
+  hostPath: /mnt/alluxio/metastore
+  # Required for volume type of persistentVolumeClaim, ignored otherwise
   storageClass: "standard"
 
 

--- a/tests/helm/expectedTemplates/conf/configmap.yaml
+++ b/tests/helm/expectedTemplates/conf/configmap.yaml
@@ -48,6 +48,9 @@ data:
     
     # Worker Identity
     alluxio.worker.identity.uuid.file.path=/mnt/alluxio/system-info/worker_identity
+    
+    # Metastore
+    alluxio.dora.worker.metastore.rocksdb.dir=/mnt/alluxio/metastore
   alluxio-env.sh: |-
     ALLUXIO_MASTER_JAVA_OPTS="-Dalluxio.master.hostname=${ALLUXIO_MASTER_HOSTNAME} masterJvmOption1 masterJvmOption2 "
     ALLUXIO_WORKER_JAVA_OPTS="-Dalluxio.worker.hostname=${ALLUXIO_WORKER_HOSTNAME} workerJvmOption1 workerJvmOption2 "

--- a/tests/helm/expectedTemplates/worker/deployment.yaml
+++ b/tests/helm/expectedTemplates/worker/deployment.yaml
@@ -129,11 +129,14 @@ spec:
           - 1000:1000
           - /mnt/alluxio/system-info
           - /opt/alluxio/logs
+          - /mnt/alluxio/metastore
         volumeMounts:
           - name: dummy-alluxio-system-info-volume
             mountPath: /mnt/alluxio/system-info
           - name: dummy-alluxio-worker-log-volume
             mountPath: /opt/alluxio/logs
+          - name: dummy-alluxio-metastore-volume
+            mountPath: /mnt/alluxio/metastore
       - name: wait-master
         image: dummy/dummy:dummy
         command: [ "/bin/sh", "-c" ]

--- a/tests/helm/expectedTemplates/worker/metastore-pvc.yaml
+++ b/tests/helm/expectedTemplates/worker/metastore-pvc.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   resources:
     requests:
-      storage: 1Gi
+      storage: 256Mi
   storageClassName: standard
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Worker uses rocksDB to store file metadata. Right now we are not persisting the rocksDB dir in k8s env. This PR persists it by default on a host machine path.