### PR TITLE
Set unique cluster name to site properties

### DIFF
--- a/deploy/charts/alluxio/templates/helpers/_alluxio-site-properties.tpl
+++ b/deploy/charts/alluxio/templates/helpers/_alluxio-site-properties.tpl
@@ -23,6 +23,7 @@ alluxio.dora.client.ufs.root={{ .Values.dataset.path }}
 {{- range $key, $val := .Values.properties }}
 {{ printf "%v=%v" $key $val }}
 {{- end }}
+alluxio.cluster.name={{ .Release.Namespace }}-{{ .Release.Name }}
 
 {{- if eq (int .Values.master.count) 1 }}
 # Master address for single master

--- a/tests/helm/expectedTemplates/conf/configmap.yaml
+++ b/tests/helm/expectedTemplates/conf/configmap.yaml
@@ -34,6 +34,7 @@ data:
     dummyCredential1=dummyVal1
     alluxio.dummyProperty0=dummy
     alluxio.dummyProperty1=dummy
+    alluxio.cluster.name=default-dummy
     
     # Journal properties
     alluxio.master.journal.type=EMBEDDED


### PR DESCRIPTION
Namespace+Name is unique to each alluxio cluster in kubernetes, so that workers of one and only one Alluxio cluster can form one ring.