### PR TITLE
Add name to artifacts metadata

### DIFF
--- a/dev/scripts/src/alluxio.org/build/artifact/artifact.go
+++ b/dev/scripts/src/alluxio.org/build/artifact/artifact.go
@@ -17,7 +17,7 @@ const (
 	DockerArtifact = ArtifactType("docker")
 	HelmArtifact   = ArtifactType("helm")
 
-	HelmChartName = "helmchart:name"
+	MetadataNameKey = "name"
 )
 
 type RepoMetadata struct {

--- a/dev/scripts/src/alluxio.org/build/cmd/docker.go
+++ b/dev/scripts/src/alluxio.org/build/cmd/docker.go
@@ -107,6 +107,7 @@ func newDockerBuildOpts(args []string) (*dockerBuildOpts, error) {
 		return nil, stacktrace.NewError("must provide valid 'image' arg")
 	}
 	opts.metadata["docker:tag"] = image.Tag
+	opts.metadata[artifact.MetadataNameKey] = opts.image
 
 	return opts, nil
 }

--- a/dev/scripts/src/alluxio.org/build/cmd/helm.go
+++ b/dev/scripts/src/alluxio.org/build/cmd/helm.go
@@ -113,7 +113,7 @@ func HelmF(args []string) error {
 			opts.outputDir,
 			chart.TargetName,
 			map[string]string{
-				artifact.HelmChartName: opts.chartName,
+				artifact.MetadataNameKey: opts.chartName,
 			},
 		)
 		return a.WriteToFile(opts.artifactOutput)

--- a/dev/scripts/src/alluxio.org/build/cmd/preset.go
+++ b/dev/scripts/src/alluxio.org/build/cmd/preset.go
@@ -98,7 +98,7 @@ func PresetsF(args []string) error {
 		}
 		a.Add(artifact.HelmArtifact, hOpts.outputDir, image.TargetName,
 			map[string]string{
-				artifact.HelmChartName: hOpts.chartName,
+				artifact.MetadataNameKey: hOpts.chartName,
 			},
 		)
 	}


### PR DESCRIPTION
use generic `name` instead of `helmchart:name` in metadata so it can be used for any type of artifact