### PR TITLE
Refactor go module name to match repo

### DIFF
--- a/cmd/alluxio/alluxio/alluxio.go
+++ b/cmd/alluxio/alluxio/alluxio.go
@@ -20,9 +20,9 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	alluxiov1alpha1 "github.com/alluxio/k8s-operator/api/v1alpha1"
-	"github.com/alluxio/k8s-operator/pkg/alluxiocluster"
-	"github.com/alluxio/k8s-operator/pkg/logger"
+	alluxiov1alpha1 "github.com/Alluxio/k8s-operator/api/v1alpha1"
+	"github.com/Alluxio/k8s-operator/pkg/alluxiocluster"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
 )
 
 var (

--- a/cmd/alluxio/main.go
+++ b/cmd/alluxio/main.go
@@ -14,8 +14,8 @@ package main
 import (
 	"os"
 
-	"github.com/alluxio/k8s-operator/cmd/alluxio/alluxio"
-	"github.com/alluxio/k8s-operator/pkg/logger"
+	"github.com/Alluxio/k8s-operator/cmd/alluxio/alluxio"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
 )
 
 func main() {

--- a/cmd/dataset/dataset/dataset.go
+++ b/cmd/dataset/dataset/dataset.go
@@ -25,12 +25,12 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	alluxiov1alpha1 "github.com/alluxio/k8s-operator/api/v1alpha1"
-	"github.com/alluxio/k8s-operator/pkg/dataset"
-	"github.com/alluxio/k8s-operator/pkg/load"
-	"github.com/alluxio/k8s-operator/pkg/logger"
-	"github.com/alluxio/k8s-operator/pkg/unload"
-	"github.com/alluxio/k8s-operator/pkg/update"
+	alluxiov1alpha1 "github.com/Alluxio/k8s-operator/api/v1alpha1"
+	"github.com/Alluxio/k8s-operator/pkg/dataset"
+	"github.com/Alluxio/k8s-operator/pkg/load"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
+	"github.com/Alluxio/k8s-operator/pkg/unload"
+	"github.com/Alluxio/k8s-operator/pkg/update"
 )
 
 var (

--- a/cmd/dataset/main.go
+++ b/cmd/dataset/main.go
@@ -14,8 +14,8 @@ package main
 import (
 	"os"
 
-	"github.com/alluxio/k8s-operator/cmd/dataset/dataset"
-	"github.com/alluxio/k8s-operator/pkg/logger"
+	"github.com/Alluxio/k8s-operator/cmd/dataset/dataset"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
 )
 
 func main() {

--- a/csi/main.go
+++ b/csi/main.go
@@ -26,7 +26,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
-	"github.com/alluxio/csi/alluxio"
+	"github.com/Alluxio/csi/alluxio"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/alluxio/k8s-operator
+module github.com/Alluxio/k8s-operator
 
 go 1.19
 

--- a/pkg/alluxiocluster/alluxiocluster_controller.go
+++ b/pkg/alluxiocluster/alluxiocluster_controller.go
@@ -20,9 +20,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	alluxiov1alpha1 "github.com/alluxio/k8s-operator/api/v1alpha1"
-	"github.com/alluxio/k8s-operator/pkg/finalizer"
-	"github.com/alluxio/k8s-operator/pkg/logger"
+	alluxiov1alpha1 "github.com/Alluxio/k8s-operator/api/v1alpha1"
+	"github.com/Alluxio/k8s-operator/pkg/finalizer"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
 )
 
 // AlluxioClusterReconciler reconciles a AlluxioCluster object

--- a/pkg/alluxiocluster/create_alluxiocluster.go
+++ b/pkg/alluxiocluster/create_alluxiocluster.go
@@ -16,8 +16,8 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"github.com/alluxio/k8s-operator/pkg/logger"
-	"github.com/alluxio/k8s-operator/pkg/utils"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
+	"github.com/Alluxio/k8s-operator/pkg/utils"
 )
 
 const chartPath = "/opt/charts/alluxio"

--- a/pkg/alluxiocluster/delete_alluxiocluster.go
+++ b/pkg/alluxiocluster/delete_alluxiocluster.go
@@ -16,8 +16,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/alluxio/k8s-operator/pkg/logger"
-	"github.com/alluxio/k8s-operator/pkg/utils"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
+	"github.com/Alluxio/k8s-operator/pkg/utils"
 )
 
 func DeleteAlluxioClusterIfExist(namespacedName types.NamespacedName) error {

--- a/pkg/alluxiocluster/update_status.go
+++ b/pkg/alluxiocluster/update_status.go
@@ -19,10 +19,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	alluxiov1alpha1 "github.com/alluxio/k8s-operator/api/v1alpha1"
-	"github.com/alluxio/k8s-operator/pkg/dataset"
-	"github.com/alluxio/k8s-operator/pkg/logger"
-	"github.com/alluxio/k8s-operator/pkg/utils"
+	alluxiov1alpha1 "github.com/Alluxio/k8s-operator/api/v1alpha1"
+	"github.com/Alluxio/k8s-operator/pkg/dataset"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
+	"github.com/Alluxio/k8s-operator/pkg/utils"
 )
 
 func UpdateStatus(alluxioClusterCtx AlluxioClusterReconcileReqCtx) (ctrl.Result, error) {

--- a/pkg/dataset/dataset_controller.go
+++ b/pkg/dataset/dataset_controller.go
@@ -20,8 +20,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	alluxiov1alpha1 "github.com/alluxio/k8s-operator/api/v1alpha1"
-	"github.com/alluxio/k8s-operator/pkg/logger"
+	alluxiov1alpha1 "github.com/Alluxio/k8s-operator/api/v1alpha1"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
 )
 
 // DatasetReconciler reconciles a Dataset object

--- a/pkg/dataset/delete_dataset.go
+++ b/pkg/dataset/delete_dataset.go
@@ -14,7 +14,7 @@ package dataset
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/alluxio/k8s-operator/pkg/logger"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
 )
 
 func DeleteDatasetIfExist(req ctrl.Request) (ctrl.Result, error) {

--- a/pkg/dataset/update_dataset_status.go
+++ b/pkg/dataset/update_dataset_status.go
@@ -16,8 +16,8 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	alluxiov1alpha1 "github.com/alluxio/k8s-operator/api/v1alpha1"
-	"github.com/alluxio/k8s-operator/pkg/logger"
+	alluxiov1alpha1 "github.com/Alluxio/k8s-operator/api/v1alpha1"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
 )
 
 func UpdateDatasetStatus(ctx DatasetReconcilerReqCtx) (ctrl.Result, error) {

--- a/pkg/load/create_load_job.go
+++ b/pkg/load/create_load_job.go
@@ -21,9 +21,9 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	alluxiov1alpha1 "github.com/alluxio/k8s-operator/api/v1alpha1"
-	"github.com/alluxio/k8s-operator/pkg/logger"
-	"github.com/alluxio/k8s-operator/pkg/utils"
+	alluxiov1alpha1 "github.com/Alluxio/k8s-operator/api/v1alpha1"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
+	"github.com/Alluxio/k8s-operator/pkg/utils"
 )
 
 func (r *LoadReconciler) createLoadJob(ctx LoadReconcilerReqCtx) (ctrl.Result, error) {

--- a/pkg/load/delete_load_job.go
+++ b/pkg/load/delete_load_job.go
@@ -16,7 +16,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/alluxio/k8s-operator/pkg/logger"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
 )
 
 func (r *LoadReconciler) deleteJob(ctx LoadReconcilerReqCtx) (ctrl.Result, error) {

--- a/pkg/load/load_controller.go
+++ b/pkg/load/load_controller.go
@@ -22,9 +22,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	alluxiov1alpha1 "github.com/alluxio/k8s-operator/api/v1alpha1"
-	"github.com/alluxio/k8s-operator/pkg/logger"
-	"github.com/alluxio/k8s-operator/pkg/utils"
+	alluxiov1alpha1 "github.com/Alluxio/k8s-operator/api/v1alpha1"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
+	"github.com/Alluxio/k8s-operator/pkg/utils"
 )
 
 type LoadReconciler struct {

--- a/pkg/unload/unload.go
+++ b/pkg/unload/unload.go
@@ -26,9 +26,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	alluxiov1alpha1 "github.com/alluxio/k8s-operator/api/v1alpha1"
-	"github.com/alluxio/k8s-operator/pkg/logger"
-	"github.com/alluxio/k8s-operator/pkg/utils"
+	alluxiov1alpha1 "github.com/Alluxio/k8s-operator/api/v1alpha1"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
+	"github.com/Alluxio/k8s-operator/pkg/utils"
 )
 
 func (r *UnloadReconciler) unload(ctx UnloadReconcilerReqCtx) (ctrl.Result, error) {

--- a/pkg/unload/unload_controller.go
+++ b/pkg/unload/unload_controller.go
@@ -21,8 +21,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 
-	alluxiov1alpha1 "github.com/alluxio/k8s-operator/api/v1alpha1"
-	"github.com/alluxio/k8s-operator/pkg/logger"
+	alluxiov1alpha1 "github.com/Alluxio/k8s-operator/api/v1alpha1"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
 )
 
 type UnloadReconciler struct {

--- a/pkg/update/create_update_job.go
+++ b/pkg/update/create_update_job.go
@@ -21,9 +21,9 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	alluxiov1alpha1 "github.com/alluxio/k8s-operator/api/v1alpha1"
-	"github.com/alluxio/k8s-operator/pkg/logger"
-	"github.com/alluxio/k8s-operator/pkg/utils"
+	alluxiov1alpha1 "github.com/Alluxio/k8s-operator/api/v1alpha1"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
+	"github.com/Alluxio/k8s-operator/pkg/utils"
 )
 
 func (r *UpdateReconciler) createUpdateJob(ctx UpdateReconcilerReqCtx) (ctrl.Result, error) {

--- a/pkg/update/delete_update_job.go
+++ b/pkg/update/delete_update_job.go
@@ -16,7 +16,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/alluxio/k8s-operator/pkg/logger"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
 )
 
 func (r *UpdateReconciler) deleteJob(ctx UpdateReconcilerReqCtx) (ctrl.Result, error) {

--- a/pkg/update/update_controller.go
+++ b/pkg/update/update_controller.go
@@ -22,9 +22,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	alluxiov1alpha1 "github.com/alluxio/k8s-operator/api/v1alpha1"
-	"github.com/alluxio/k8s-operator/pkg/logger"
-	"github.com/alluxio/k8s-operator/pkg/utils"
+	alluxiov1alpha1 "github.com/Alluxio/k8s-operator/api/v1alpha1"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
+	"github.com/Alluxio/k8s-operator/pkg/utils"
 )
 
 type UpdateReconciler struct {

--- a/pkg/utils/component_utils.go
+++ b/pkg/utils/component_utils.go
@@ -18,8 +18,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	alluxiov1alpha1 "github.com/alluxio/k8s-operator/api/v1alpha1"
-	"github.com/alluxio/k8s-operator/pkg/logger"
+	alluxiov1alpha1 "github.com/Alluxio/k8s-operator/api/v1alpha1"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
 )
 
 type ComponentStatusReqCtx struct {

--- a/pkg/utils/helm.go
+++ b/pkg/utils/helm.go
@@ -14,7 +14,7 @@ package utils
 import (
 	"os/exec"
 
-	"github.com/alluxio/k8s-operator/pkg/logger"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
 )
 
 type HelmContext struct {

--- a/pkg/utils/kube_client.go
+++ b/pkg/utils/kube_client.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	"github.com/alluxio/k8s-operator/pkg/logger"
+	"github.com/Alluxio/k8s-operator/pkg/logger"
 )
 
 func GetK8sClient() (*kubernetes.Clientset, error) {


### PR DESCRIPTION
`github.com/alluxio/k8s-operator` to `github.com/Alluxio/k8s-operator` for consistency with actual repo name. 

running into errors when trying to use as dep
```
go get github.com/Alluxio/k8s-operator@v1.0.1                                                                                                                                                                           
go: github.com/Alluxio/k8s-operator@v1.0.1: parsing go.mod:
	module declares its path as: github.com/alluxio/k8s-operator
	        but was required as: github.com/Alluxio/k8s-operator
```