### PR TITLE
Give k8s env property a default true value

### DIFF
--- a/deploy/charts/alluxio/templates/helpers/_alluxio-site-properties.tpl
+++ b/deploy/charts/alluxio/templates/helpers/_alluxio-site-properties.tpl
@@ -16,6 +16,7 @@ alluxio.user.short.circuit.enabled=false
 alluxio.master.worker.register.lease.enabled=false
 
 # Common properties
+alluxio.k8s.env.deployment=true
 {{- if ne (get .Values.properties "alluxio.mount.table.source") "ETCD" }}
 alluxio.dora.client.ufs.root={{ .Values.dataset.path }}
 {{- end }}

--- a/tests/helm/expectedTemplates/conf/configmap.yaml
+++ b/tests/helm/expectedTemplates/conf/configmap.yaml
@@ -29,6 +29,7 @@ data:
     alluxio.master.worker.register.lease.enabled=false
     
     # Common properties
+    alluxio.k8s.env.deployment=true
     alluxio.dora.client.ufs.root=/dummy/dataset/path
     dummyCredential0=dummyVal0
     dummyCredential1=dummyVal1


### PR DESCRIPTION
According to https://github.com/Alluxio/alluxio/pull/18454, to enable the worker identity feature on k8s, need to set `alluxio.k8s.env.deployment` to true.